### PR TITLE
[MON-12] feat : 시리즈 create API 구현

### DIFF
--- a/src/main/java/com/prgrms/monthsub/common/utils/TimeUtil.java
+++ b/src/main/java/com/prgrms/monthsub/common/utils/TimeUtil.java
@@ -1,0 +1,14 @@
+package com.prgrms.monthsub.common.utils;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+public class TimeUtil {
+
+    public static String convertUploadDateListToUploadDateString(String[] uploadDateList) {
+        return StringUtils.chop(
+            Arrays.stream(uploadDateList).map(s -> s + "$").collect(Collectors.joining()));
+    }
+
+}

--- a/src/main/java/com/prgrms/monthsub/controller/SeriesController.java
+++ b/src/main/java/com/prgrms/monthsub/controller/SeriesController.java
@@ -3,9 +3,10 @@ package com.prgrms.monthsub.controller;
 import com.prgrms.monthsub.common.error.ApiResponse;
 import com.prgrms.monthsub.dto.request.SeriesSubscribePostRequest;
 import com.prgrms.monthsub.dto.response.SeriesSubscribePostResponse;
-import com.prgrms.monthsub.service.S3Uploader;
+import com.prgrms.monthsub.service.SeriesService;
 import io.swagger.v3.oas.annotations.Operation;
 import java.io.IOException;
+import javax.validation.Valid;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,20 +19,19 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/series")
 public class SeriesController {
 
-    private static final String DIRECTORY = "seriesThumbnails";
+    private final SeriesService seriesService;
 
-    private final S3Uploader s3Uploader;
-
-    public SeriesController(S3Uploader s3Uploader) {this.s3Uploader = s3Uploader;}
+    public SeriesController(SeriesService seriesService) {
+        this.seriesService = seriesService;
+    }
 
     @Operation(summary = "시리즈 공고 게시글을 작성할 수 있습니다.")
-    @PostMapping("/writers/{writerId}")
-    public ApiResponse<SeriesSubscribePostResponse> postSeries(@PathVariable Long writerId,
+    @PostMapping("/users/{userId}")
+    public ApiResponse<SeriesSubscribePostResponse> postSeries(
+        @PathVariable Long userId,
         @RequestPart MultipartFile thumbnail,
-        @RequestPart SeriesSubscribePostRequest request) throws IOException {
-        s3Uploader.upload(thumbnail, DIRECTORY);
-
-        return ApiResponse.ok(HttpMethod.POST, null);
+        @Valid @RequestPart SeriesSubscribePostRequest request) throws IOException {
+        return ApiResponse.ok(HttpMethod.POST, seriesService.createSeries(userId, thumbnail, request));
     }
 
 }

--- a/src/main/java/com/prgrms/monthsub/controller/SeriesController.java
+++ b/src/main/java/com/prgrms/monthsub/controller/SeriesController.java
@@ -5,6 +5,7 @@ import com.prgrms.monthsub.dto.request.SeriesSubscribePostRequest;
 import com.prgrms.monthsub.dto.response.SeriesSubscribePostResponse;
 import com.prgrms.monthsub.service.SeriesService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import javax.validation.Valid;
 import org.springframework.http.HttpMethod;
@@ -17,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/series")
+@Tag(name = "시리즈 관련 화면", description = " API 목록입니다.")
 public class SeriesController {
 
     private final SeriesService seriesService;

--- a/src/main/java/com/prgrms/monthsub/converter/SeriesConverter.java
+++ b/src/main/java/com/prgrms/monthsub/converter/SeriesConverter.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class SeriesConverter {
 
+    private static final int DEFAULT_LIKES = 0;
+
     public Series SeriesSubscribePostResponseToEntity(Writer writer, String imageUrl,
         SeriesSubscribePostRequest req) {
         return Series.builder()
@@ -28,7 +30,7 @@ public class SeriesConverter {
             .seriesEndDate(LocalDate.parse(req.seriesEndDate()))
             .articleCount(req.articleCount())
             .subscribeStatus(SeriesStatus.SUBSCRIPTION_AVAILABLE)
-            .likes(0)
+            .likes(DEFAULT_LIKES)
             .uploadDate(convertUploadDateListToUploadDateString(req.uploadDate()))
             .category(Category.of(req.category()))
             .uploadTime(LocalTime.parse(req.uploadTime()))

--- a/src/main/java/com/prgrms/monthsub/converter/SeriesConverter.java
+++ b/src/main/java/com/prgrms/monthsub/converter/SeriesConverter.java
@@ -1,0 +1,39 @@
+package com.prgrms.monthsub.converter;
+
+import static com.prgrms.monthsub.common.utils.TimeUtil.convertUploadDateListToUploadDateString;
+
+import com.prgrms.monthsub.domain.Series;
+import com.prgrms.monthsub.domain.Writer;
+import com.prgrms.monthsub.domain.enumType.Category;
+import com.prgrms.monthsub.domain.enumType.SeriesStatus;
+import com.prgrms.monthsub.dto.request.SeriesSubscribePostRequest;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SeriesConverter {
+
+    public Series SeriesSubscribePostResponseToEntity(Writer writer, String imageUrl,
+        SeriesSubscribePostRequest req) {
+        return Series.builder()
+            .thumbnail(imageUrl)
+            .title(req.title())
+            .introduceText(req.introduceText())
+            .introduceSentence(req.introduceSentence())
+            .price(req.price())
+            .subscribeStartDate(LocalDate.parse(req.subscribeStartDate()))
+            .subscribeEndDate(LocalDate.parse(req.subscribeEndDate()))
+            .seriesStartDate(LocalDate.parse(req.seriesStartDate()))
+            .seriesEndDate(LocalDate.parse(req.seriesEndDate()))
+            .articleCount(req.articleCount())
+            .subscribeStatus(SeriesStatus.SUBSCRIPTION_AVAILABLE)
+            .likes(0)
+            .uploadDate(convertUploadDateListToUploadDateString(req.uploadDate()))
+            .category(Category.of(req.category()))
+            .uploadTime(LocalTime.parse(req.uploadTime()))
+            .writer(writer)
+            .build();
+    }
+
+}

--- a/src/main/java/com/prgrms/monthsub/domain/Series.java
+++ b/src/main/java/com/prgrms/monthsub/domain/Series.java
@@ -74,6 +74,7 @@ public class Series {
     @Column(name = "likes", columnDefinition = "INT")
     private int likes;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "category", columnDefinition = "VARCHAR(50)")
     private Category category;
 

--- a/src/main/java/com/prgrms/monthsub/domain/User.java
+++ b/src/main/java/com/prgrms/monthsub/domain/User.java
@@ -71,4 +71,8 @@ public class User extends BaseEntity {
         }
     }
 
+    public void changePart(Part part) {
+        this.part = part;
+    }
+
 }

--- a/src/main/java/com/prgrms/monthsub/domain/enumType/Category.java
+++ b/src/main/java/com/prgrms/monthsub/domain/enumType/Category.java
@@ -10,6 +10,6 @@ public enum Category {
     ETC;
 
     public static Category of(String category) {
-        return Category.valueOf(category);
+        return Category.valueOf(category.toUpperCase());
     }
 }

--- a/src/main/java/com/prgrms/monthsub/domain/enumType/SeriesStatus.java
+++ b/src/main/java/com/prgrms/monthsub/domain/enumType/SeriesStatus.java
@@ -6,6 +6,6 @@ public enum SeriesStatus {
     SUBSCRIPTION_AVAILABLE;
 
     public static SeriesStatus of(String seriesStatus) {
-        return SeriesStatus.valueOf(seriesStatus);
+        return SeriesStatus.valueOf(seriesStatus.toUpperCase());
     }
 }

--- a/src/main/java/com/prgrms/monthsub/dto/request/SeriesSubscribePostRequest.java
+++ b/src/main/java/com/prgrms/monthsub/dto/request/SeriesSubscribePostRequest.java
@@ -1,4 +1,46 @@
 package com.prgrms.monthsub.dto.request;
 
-public record SeriesSubscribePostRequest(){
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Positive;
+
+public record SeriesSubscribePostRequest(
+
+    @NotBlank(message = "닉네임이 비어있습니다.")
+    String nickname,
+
+    @NotBlank(message = "제목이 비어있습니다.")
+    String title,
+
+    @NotBlank(message = "닉네임이 비어있습니다.")
+    String introduceSentence,
+
+    @NotBlank(message = "소개문장이 비어있습니다.")
+    String introduceText,
+
+    @NotBlank(message = "구독 시작 날짜가 비어있습니다.")
+    String subscribeStartDate,
+
+    @NotBlank(message = "구독 종료 날짜가 비어있습니다.")
+    String subscribeEndDate,
+
+    @NotBlank(message = "연재 시작 날짜가 비어있습니다.")
+    String seriesStartDate,
+
+    @NotBlank(message = "연재 종료 날짜가 비어있습니다.")
+    String seriesEndDate,
+
+    @NotBlank(message = "카테고리가 비어있습니다.")
+    String category,
+
+    String[] uploadDate,
+
+    @NotBlank(message = "업로드 시간이 비어있습니다.")
+    String uploadTime,
+
+    @Positive
+    int articleCount,
+
+    @Positive
+    int price
+) {
 }

--- a/src/main/java/com/prgrms/monthsub/dto/response/SeriesSubscribePostResponse.java
+++ b/src/main/java/com/prgrms/monthsub/dto/response/SeriesSubscribePostResponse.java
@@ -1,4 +1,6 @@
 package com.prgrms.monthsub.dto.response;
 
-public record SeriesSubscribePostResponse(){
+public record SeriesSubscribePostResponse(
+    Long seriesId
+) {
 }

--- a/src/main/java/com/prgrms/monthsub/repository/PartRepository.java
+++ b/src/main/java/com/prgrms/monthsub/repository/PartRepository.java
@@ -1,0 +1,11 @@
+package com.prgrms.monthsub.repository;
+
+import com.prgrms.monthsub.domain.Part;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PartRepository extends JpaRepository<Part, Long> {
+
+    Optional<Part> findByName(String name);
+
+}

--- a/src/main/java/com/prgrms/monthsub/repository/SeriesRepository.java
+++ b/src/main/java/com/prgrms/monthsub/repository/SeriesRepository.java
@@ -1,0 +1,7 @@
+package com.prgrms.monthsub.repository;
+
+import com.prgrms.monthsub.domain.Series;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeriesRepository extends JpaRepository<Series, Long> {
+}

--- a/src/main/java/com/prgrms/monthsub/repository/WriterRepository.java
+++ b/src/main/java/com/prgrms/monthsub/repository/WriterRepository.java
@@ -1,0 +1,11 @@
+package com.prgrms.monthsub.repository;
+
+import com.prgrms.monthsub.domain.Writer;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WriterRepository extends JpaRepository<Writer, Long> {
+
+    Optional<Writer> findByUserId(Long userId);
+
+}

--- a/src/main/java/com/prgrms/monthsub/service/PartService.java
+++ b/src/main/java/com/prgrms/monthsub/service/PartService.java
@@ -1,0 +1,21 @@
+package com.prgrms.monthsub.service;
+
+import com.prgrms.monthsub.common.error.ErrorCode;
+import com.prgrms.monthsub.common.error.exception.EntityNotFoundException;
+import com.prgrms.monthsub.domain.Part;
+import com.prgrms.monthsub.repository.PartRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PartService {
+
+    private final PartRepository writerRepository;
+
+    public PartService(PartRepository writerRepository) {this.writerRepository = writerRepository;}
+
+    public Part findByName(String name) {
+        return writerRepository.findByName(name)
+            .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/prgrms/monthsub/service/SeriesService.java
+++ b/src/main/java/com/prgrms/monthsub/service/SeriesService.java
@@ -1,0 +1,45 @@
+package com.prgrms.monthsub.service;
+
+import com.prgrms.monthsub.converter.SeriesConverter;
+import com.prgrms.monthsub.domain.Series;
+import com.prgrms.monthsub.domain.Writer;
+import com.prgrms.monthsub.dto.request.SeriesSubscribePostRequest;
+import com.prgrms.monthsub.dto.response.SeriesSubscribePostResponse;
+import com.prgrms.monthsub.repository.SeriesRepository;
+import java.io.IOException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public class SeriesService {
+
+    private static final String DIRECTORY = "seriesThumbnails";
+
+    private final SeriesRepository seriesRepository;
+
+    private final WriterService writerService;
+
+    private final S3Uploader s3Uploader;
+
+    private final SeriesConverter seriesConverter;
+
+    public SeriesService(SeriesRepository seriesRepository,
+        WriterService writerService, SeriesConverter seriesConverter,
+        S3Uploader s3Uploader) {
+        this.seriesRepository = seriesRepository;
+        this.writerService = writerService;
+        this.seriesConverter = seriesConverter;
+        this.s3Uploader = s3Uploader;
+    }
+
+    @Transactional
+    public SeriesSubscribePostResponse createSeries(Long userId, MultipartFile thumbnail,
+        SeriesSubscribePostRequest request) throws IOException {
+        String imageUrl = s3Uploader.upload(thumbnail, DIRECTORY);
+        Writer writer = writerService.findByUserId(userId);
+        Series entity = seriesConverter.SeriesSubscribePostResponseToEntity(writer, imageUrl, request);
+        return new SeriesSubscribePostResponse(seriesRepository.save(entity).getId());
+    }
+
+}

--- a/src/main/java/com/prgrms/monthsub/service/UserService.java
+++ b/src/main/java/com/prgrms/monthsub/service/UserService.java
@@ -1,6 +1,7 @@
 package com.prgrms.monthsub.service;
 
-
+import com.prgrms.monthsub.common.error.ErrorCode;
+import com.prgrms.monthsub.common.error.exception.EntityNotFoundException;
 import com.prgrms.monthsub.common.error.exception.UserNotFoundException;
 import com.prgrms.monthsub.domain.User;
 import com.prgrms.monthsub.repository.UserRepository;
@@ -28,6 +29,11 @@ public class UserService {
             .orElseThrow(UserNotFoundException::new);
         user.checkPassword(passwordEncoder, credentials);
         return user;
+    }
+
+    public User findByUserId(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
     }
 
     public Optional<User> findByUserName(String username) {

--- a/src/main/java/com/prgrms/monthsub/service/WriterService.java
+++ b/src/main/java/com/prgrms/monthsub/service/WriterService.java
@@ -1,0 +1,50 @@
+package com.prgrms.monthsub.service;
+
+import com.prgrms.monthsub.domain.Part;
+import com.prgrms.monthsub.domain.User;
+import com.prgrms.monthsub.domain.Writer;
+import com.prgrms.monthsub.repository.WriterRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class WriterService {
+
+    private static final int DEFAULT_FOLLOW_COUNT = 0;
+
+    private final WriterRepository writerRepository;
+
+    private final PartService partService;
+
+    private final UserService userService;
+
+    public WriterService(WriterRepository writerRepository,
+        PartService partService, UserService userService) {
+        this.writerRepository = writerRepository;
+        this.partService = partService;
+        this.userService = userService;
+    }
+
+    @Transactional
+    public Writer findByUserId(Long userId) {
+        return writerRepository.findByUserId(userId).orElseGet(() ->
+            this.getWriterAndChangeUserPart(userId));
+    }
+
+    private Writer getWriterAndChangeUserPart(Long userId) {
+        User user = userService.findByUserId(userId);
+
+        //TODO : PART NAME ENUM으로 관리 필요.
+        Part part = partService.findByName("AUTHOR_GROUP");
+        user.changePart(part);
+
+        Writer entity = Writer.builder()
+            .followCount(DEFAULT_FOLLOW_COUNT)
+            .user(user)
+            .build();
+
+        writerRepository.save(entity);
+        return entity;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,8 @@ spring:
     ansi.enabled: always
   servlet:
     multipart:
-      maxFileSize: 20MB
-      maxRequestSize: 20MB
+      maxFileSize: 5MB
+      maxRequestSize: 5MB
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,8 @@ spring:
     ansi.enabled: always
   servlet:
     multipart:
-      maxFileSize: 5MB
-      maxRequestSize: 5MB
+      maxFileSize: 20MB
+      maxRequestSize: 20MB
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## 🦓 지라 link
https://monthsub.atlassian.net/jira/software/projects/MON/boards/1

## 👩‍💻 AS-IS

- [x] :  시리즈 구독 공고 모집 API를 구현하였습니다.

## 📌 TO-BE
- part name을 enum으로 관리하면 좋을 것 같습니다.
- 내 정보 조회 코드 추가 이후에 로그인 된 유저만 접근할 수 있도록 @AuthenticationPrincipal JwtAuthentication authentication 붙여줘야 합니다.
- 테스트 코드는 추가해야합니다.
- 에러 처리도 추가해야합니다. 
