### PR TITLE
[MON-86] fix : 시리즈 조회 API 에러 수정

### DIFF
--- a/src/main/java/com/prgrms/monthsub/dto/response/SeriesOneResponse.java
+++ b/src/main/java/com/prgrms/monthsub/dto/response/SeriesOneResponse.java
@@ -18,64 +18,64 @@ public record SeriesOneResponse(
     @Builder
     public static class SeriesObject {
 
-        private Long id;
+        public Long id;
 
-        private String thumbnail;
+        public String thumbnail;
 
-        private String title;
+        public String title;
 
-        private String introduceText;
+        public String introduceText;
 
-        private String introduceSentence;
+        public String introduceSentence;
 
-        private int price;
+        public int price;
 
-        private LocalDate startDate;
+        public LocalDate startDate;
 
-        private LocalDate endDate;
+        public LocalDate endDate;
 
-        private int articleCount;
+        public int articleCount;
 
-        private int likes;
+        public int likes;
 
     }
 
     @Builder
     public static class UploadObject {
 
-        private String[] date;
+        public String[] date;
 
-        private LocalTime time;
+        public LocalTime time;
 
     }
 
     @Builder
     public static class SubscribeObject {
 
-        private LocalDate startDate;
+        public LocalDate startDate;
 
-        private LocalDate endDate;
+        public LocalDate endDate;
 
-        private String status;
+        public String status;
 
     }
 
     @Builder
     public static class WriterObject {
 
-        private Long id;
+        public Long id;
 
-        private Long userId;
+        public Long userId;
 
-        private int followCount;
+        public int followCount;
 
-        private String email;
+        public String email;
 
-        private String profileImage;
+        public String profileImage;
 
-        private String profileIntroduce;
+        public String profileIntroduce;
 
-        private String nickname;
+        public String nickname;
 
     }
 

--- a/src/main/java/com/prgrms/monthsub/repository/ArticleRepository.java
+++ b/src/main/java/com/prgrms/monthsub/repository/ArticleRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
-    @Query("select a from Article as a where a.series = :seriesId")
+    @Query("select a from Article as a where a.series.id = :seriesId")
     List<Article> findAllArticleBySeriesId(@Param("seriesId") Long seriesId);
 
 }


### PR DESCRIPTION
## 🦓 지라 link

https://monthsub.atlassian.net/browse/MON-86?atlOrigin=eyJpIjoiNmRmNGVhODcyNjdiNDQyMzk4ZjM4YWFjODRjOTIzNWIiLCJwIjoiaiJ9

## 👩‍💻 AS-IS

- [x] :  조회 API 에러 수정 
	* json 직렬화 과정에서 에러발생,  `response` 에서 사용하는 객체[SeriesOneResponse]의 `private -> public` 으로 변경
