### PR TITLE
[MON-90] feat:  이미지 단일 API 업로드 구현

### DIFF
--- a/src/main/java/com/prgrms/monthsub/common/error/ErrorCodes.java
+++ b/src/main/java/com/prgrms/monthsub/common/error/ErrorCodes.java
@@ -22,7 +22,7 @@ public record ErrorCodes(ErrorCode errorCode, String message) {
     }
 
     public static ErrorCodes INVALID_UPLOAD_FILE_TYPE() {
-        return new ErrorCodes(ErrorCode.INVALID_UPLOAD_FILE_TYPE, "아이디 혹은 비밀번호가 일치하지 않습니다.");
+        return new ErrorCodes(ErrorCode.INVALID_UPLOAD_FILE_TYPE, "jpeg, jpg, png 형식만 가능합니다.");
     }
 
     public static ErrorCodes UN_AUTHORIZED() {

--- a/src/main/java/com/prgrms/monthsub/common/error/exception/global/S3Exception.java
+++ b/src/main/java/com/prgrms/monthsub/common/error/exception/global/S3Exception.java
@@ -1,5 +1,0 @@
-package com.prgrms.monthsub.common.error.exception.global;
-
-public class S3Exception {
-
-}

--- a/src/main/java/com/prgrms/monthsub/common/error/exception/global/S3UploaderException.java
+++ b/src/main/java/com/prgrms/monthsub/common/error/exception/global/S3UploaderException.java
@@ -1,0 +1,15 @@
+package com.prgrms.monthsub.common.error.exception.global;
+
+import com.prgrms.monthsub.common.error.ErrorCodes;
+
+public class S3UploaderException {
+
+    public static class ImageExtensionNotMatch extends BusinessException {
+
+        public ImageExtensionNotMatch() {
+            super(ErrorCodes.INVALID_UPLOAD_FILE_TYPE());
+        }
+
+    }
+
+}

--- a/src/main/java/com/prgrms/monthsub/controller/SeriesController.java
+++ b/src/main/java/com/prgrms/monthsub/controller/SeriesController.java
@@ -31,6 +31,8 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "Series")
 public class SeriesController {
 
+    private static final String THUMBNAIL = "thumbnail";
+
     private final SeriesService seriesService;
 
     public SeriesController(SeriesService seriesService) {
@@ -69,7 +71,7 @@ public class SeriesController {
     public ApiResponse<SeriesSubscribeEdit.Response> editSeries(
         @AuthenticationPrincipal JwtAuthentication authentication,
         @PathVariable Long seriesId,
-        @RequestPart(required = false) MultipartFile thumbnail,
+        @RequestPart MultipartFile thumbnail,
         @Valid @RequestPart SeriesSubscribeEdit.Request request) throws IOException {
         return ApiResponse.ok(
             HttpMethod.PUT, seriesService.editSeries(seriesId, authentication.userId, thumbnail, request));
@@ -83,6 +85,16 @@ public class SeriesController {
         @PathVariable Long id
     ) {
         return ApiResponse.ok(HttpMethod.GET, seriesService.getSeriesUsageEdit(id));
+    }
+
+    @PostMapping(path = "/thumbnail", consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
+    @Operation(summary = "시리즈 썸네일 이미지 업로드")
+    @Tag(name = "[사진 업로드]")
+    public ApiResponse<String> registerImage(
+        @AuthenticationPrincipal JwtAuthentication authentication,
+        @RequestPart MultipartFile image) throws IOException {
+        return ApiResponse.ok(
+            HttpMethod.POST, seriesService.uploadImage(image, authentication.userId, THUMBNAIL));
     }
 
 

--- a/src/main/java/com/prgrms/monthsub/controller/UserController.java
+++ b/src/main/java/com/prgrms/monthsub/controller/UserController.java
@@ -1,6 +1,5 @@
 package com.prgrms.monthsub.controller;
 
-
 import com.prgrms.monthsub.common.error.ApiResponse;
 import com.prgrms.monthsub.domain.User;
 import com.prgrms.monthsub.dto.UserLogin;
@@ -11,18 +10,26 @@ import com.prgrms.monthsub.jwt.JwtAuthenticationToken;
 import com.prgrms.monthsub.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
+@RequestMapping("/users")
 @Tag(name = "Users")
 public class UserController {
+
+    private static final String PROFILE = "profile";
 
     private final UserService userService;
 
@@ -33,7 +40,7 @@ public class UserController {
         this.authenticationManager = authenticationManager;
     }
 
-    @PostMapping(path = "/users/login")
+    @PostMapping(path = "/login")
     @Operation(summary = "로그인")
     @Tag(name = "[화면]-로그인")
     public ApiResponse<UserLogin.Response> login(@RequestBody UserLogin.Request request) {
@@ -47,7 +54,7 @@ public class UserController {
         ));
     }
 
-    @GetMapping(path = "/users/me")
+    @GetMapping(path = "/me")
     @Operation(summary = "내 정보 확인")
     @Tag(name = "[화면]-내정보")
     public ApiResponse<UserMe.Response> me(
@@ -62,11 +69,21 @@ public class UserController {
         return ApiResponse.ok(HttpMethod.GET, me);
     }
 
-    @PostMapping(path = "/users/signup")
+    @PostMapping(path = "/signup")
     @Operation(summary = "회원가입")
     @Tag(name = "[화면]-회원가입")
     public ApiResponse<UserSignUp.Response> signUp(@RequestBody UserSignUp.Request request) {
         return ApiResponse.ok(HttpMethod.POST, userService.signUp(request));
+    }
+
+    @PostMapping(path = "/profile", consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
+    @Operation(summary = "유저 프로필 이미지 업로드")
+    @Tag(name = "[사진 업로드]")
+    public ApiResponse<String> registerImage(
+        @AuthenticationPrincipal JwtAuthentication authentication,
+        @RequestPart(required = false) MultipartFile image) throws IOException {
+        return ApiResponse.ok(
+            HttpMethod.POST, userService.uploadImage(image, authentication.userId, PROFILE));
     }
 
 }


### PR DESCRIPTION
## 🦓 지라 link
https://monthsub.atlassian.net/browse/MON-90?atlOrigin=eyJpIjoiYjgzNjM0ZjkwNDU1NGU0ZmJjODEwMmFhNTk5YTQyMTUiLCJwIjoiaiJ9

## 👩‍💻 AS-IS

- [x] :  시리즈 도메인은 썸네일이 Null 을 허용하지 않습니다. 시리즈 수정할 경우에 null 허용이 가능한 상태로 되어있는 옵션값을 제거하였습니다. 시리즈 썸네일은 유저가 무조건 데이터를 보낼 수 있도록 해야할 것 같습니다. 

- [x] :  유저 도메인에서 데이터가 null 들어올 수 있도록 설정해놓았고, null 일 경우 profile field 를 null 로 갱신하는 부분은 담당자분께서 작업 이어서 해주시면 됩니다. 주석으로 작성해 놓았습니다.(UserService.class 57 라인)

- [x] series/{userId}/thumbnail 하위에 시리즈 썸네일 이미지가 저장됩니다.
- [x] user/{userId}/profile 하위에 프로필 이미지가 저장됩니다.

## 📌 TO-BE 
- 포스트 썸네일 갱신 엔드포인트는 포스트 api 구현 작업하면서 할 예정입니다.