### PR TITLE
[MON-24] feat:  아티클 수정 API 구현

### DIFF
--- a/src/main/java/com/prgrms/monthsub/module/series/article/app/ArticleAssemble.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/app/ArticleAssemble.java
@@ -1,61 +1,137 @@
 package com.prgrms.monthsub.module.series.article.app;
 
+import com.prgrms.monthsub.common.utils.S3Uploader;
+import com.prgrms.monthsub.config.S3.Bucket;
 import com.prgrms.monthsub.module.series.article.converter.ArticleConverter;
 import com.prgrms.monthsub.module.series.article.domain.Article;
+import com.prgrms.monthsub.module.series.article.dto.ArticleEdit;
 import com.prgrms.monthsub.module.series.article.dto.ArticlePost;
 import com.prgrms.monthsub.module.series.series.app.SeriesService;
 import com.prgrms.monthsub.module.series.series.domain.Series;
+import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion;
+import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.ExpulsionImageName;
+import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.ExpulsionImageStatus;
+import com.prgrms.monthsub.module.worker.explusion.domain.ExpulsionService;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
 
 @Service
 @Transactional(readOnly = true)
 public class ArticleAssemble {
 
-    private final ArticleService articleService;
+  private final ArticleService articleService;
 
-    private final SeriesService seriesService;
+  private final SeriesService seriesService;
 
-    private final ArticleConverter articleConverter;
+  private final ExpulsionService expulsionService;
 
-    public ArticleAssemble(
-            ArticleService articleService,
-            SeriesService seriesService,
-            ArticleConverter articleConverter
-    ) {
-        this.articleService = articleService;
-        this.seriesService = seriesService;
-        this.articleConverter = articleConverter;
-    }
+  private final ArticleConverter articleConverter;
 
-    @Transactional
-    public ArticlePost.Response createArticle(
-            MultipartFile thumbnail,
-            ArticlePost.Request request
-    ) throws IOException {
-        Series series = this.seriesService.getById(request.seriesId());
+  private final S3Uploader s3Uploader;
 
-        Long articleCount = this.articleService.countBySeriesId(request.seriesId());
+  public ArticleAssemble(
+    ArticleService articleService,
+    SeriesService seriesService,
+    ExpulsionService expulsionService,
+    ArticleConverter articleConverter,
+    S3Uploader s3Uploader
+  ) {
+    this.articleService = articleService;
+    this.seriesService = seriesService;
+    this.expulsionService = expulsionService;
+    this.articleConverter = articleConverter;
+    this.s3Uploader = s3Uploader;
+  }
 
-        Article article = articleConverter.ArticlePostToEntity(
-                series,
-                request,
-                articleCount.intValue() + 1
-        );
-        this.articleService.save(article);
+  @Transactional
+  public ArticlePost.Response createArticle(
+    MultipartFile thumbnail,
+    ArticlePost.Request request
+  ) throws IOException {
+    Series series = this.seriesService.getById(request.seriesId());
 
-        String thumbnailKey = this.articleService.uploadThumbnailImage(
-                thumbnail,
-                request.seriesId(),
-                article.getId()
-        );
+    Long articleCount = this.articleService.countBySeriesId(request.seriesId());
 
-        article.changeThumbnailKey(thumbnailKey);
+    Article article = articleConverter.ArticlePostToEntity(
+      series,
+      request,
+      articleCount.intValue() + 1
+    );
+    this.articleService.save(article);
 
-        return new ArticlePost.Response(article.getId());
-    }
+    String thumbnailKey = this.uploadThumbnailImage(
+      thumbnail,
+      request.seriesId(),
+      article.getId()
+    );
+
+    article.changeThumbnailKey(thumbnailKey);
+
+    return new ArticlePost.Response(article.getId());
+  }
+
+  @Transactional
+  public ArticleEdit.TextChangeResponse editArticle(
+    Long id,
+    ArticleEdit.TextChangeRequest request
+  ) {
+    Article article = articleService.find(id);
+    article.changeWriting(request.title(), request.contents());
+
+    return new ArticleEdit.TextChangeResponse(article.getId());
+  }
+
+  @Transactional
+  public String changeThumbnail(
+    MultipartFile thumbnail,
+    Long seriesId,
+    Long articleId,
+    Long userId
+  ) {
+    Article article = articleService.find(articleId);
+
+    String originalThumbnailKey = article.getThumbnailKey();
+
+    String thumbnailKey = this.uploadThumbnailImage(
+      thumbnail,
+      seriesId,
+      articleId
+    );
+
+    Expulsion expulsion = Expulsion.builder()
+      .userId(userId)
+      .imageKey(originalThumbnailKey)
+      .expulsionImageStatus(ExpulsionImageStatus.CREATED)
+      .expulsionImageName(ExpulsionImageName.ARTICLE_THUMBNAIL)
+      .hardDeleteDate(LocalDateTime.now())
+      .build();
+    this.expulsionService.save(expulsion);
+
+    article.changeThumbnailKey(thumbnailKey);
+
+    return this.articleConverter.toThumbnailEndpoint(thumbnailKey);
+  }
+
+  protected String uploadThumbnailImage(
+    MultipartFile image,
+    Long seriesId,
+    Long articleId
+  ) {
+    String key = Series.class.getSimpleName()
+      .toLowerCase()
+      + "/" + seriesId.toString()
+      + "/" + Article.class.getSimpleName()
+      .toLowerCase()
+      + "/" + articleId.toString()
+      + "/thumbnail/"
+      + UUID.randomUUID() +
+      this.s3Uploader.getExtension(image);
+
+    return this.s3Uploader.upload(Bucket.IMAGE, image, key, S3Uploader.imageExtensions);
+  }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/article/app/ArticleAssemble.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/app/ArticleAssemble.java
@@ -22,15 +22,10 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @Transactional(readOnly = true)
 public class ArticleAssemble {
-
   private final ArticleService articleService;
-
   private final SeriesService seriesService;
-
   private final ExpulsionService expulsionService;
-
   private final ArticleConverter articleConverter;
-
   private final S3Uploader s3Uploader;
 
   public ArticleAssemble(

--- a/src/main/java/com/prgrms/monthsub/module/series/article/app/ArticleController.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/app/ArticleController.java
@@ -2,44 +2,79 @@ package com.prgrms.monthsub.module.series.article.app;
 
 import com.prgrms.monthsub.common.exception.model.ApiResponse;
 import com.prgrms.monthsub.common.jwt.JwtAuthentication;
+import com.prgrms.monthsub.module.series.article.dto.ArticleEdit;
 import com.prgrms.monthsub.module.series.article.dto.ArticlePost;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
+import javax.validation.Valid;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
-import java.io.IOException;
-
 @RestController
+@RequestMapping("/article")
 @Tag(name = "Article")
 public class ArticleController {
 
-    private final ArticleAssemble articleAssemble;
+  private final ArticleAssemble articleAssemble;
 
-    public ArticleController(
-            ArticleAssemble articleAssemble
-    ) {
-        this.articleAssemble = articleAssemble;
-    }
+  public ArticleController(
+    ArticleAssemble articleAssemble
+  ) {
+    this.articleAssemble = articleAssemble;
+  }
 
-    @PostMapping(path = "/article", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    @Operation(summary = "아티클 작성")
-    @Tag(name = "[화면]-아티클")
-    public ApiResponse<ArticlePost.Response> postArticle(
-            @AuthenticationPrincipal JwtAuthentication authentication,
-            @RequestPart MultipartFile thumbnail,
-            @Valid @RequestPart ArticlePost.Request request
-    ) throws IOException {
-        return ApiResponse.ok(
-                HttpMethod.POST,
-                articleAssemble.createArticle(thumbnail, request)
-        );
-    }
+  @PostMapping(consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
+  @Operation(summary = "아티클 작성")
+  @Tag(name = "[화면]-아티클")
+  public ApiResponse<ArticlePost.Response> postArticle(
+    @AuthenticationPrincipal JwtAuthentication authentication,
+    @RequestPart MultipartFile thumbnail,
+    @Valid @RequestPart ArticlePost.Request request
+  ) throws IOException {
+    return ApiResponse.ok(
+      HttpMethod.POST,
+      articleAssemble.createArticle(thumbnail, request)
+    );
+  }
+
+  @PutMapping(path = "/{id}")
+  @Operation(summary = "아티클 텍스트 정보 수정")
+  @Tag(name = "[화면]-아티클")
+  public ApiResponse<ArticleEdit.TextChangeResponse> editArticle(
+    @AuthenticationPrincipal JwtAuthentication authentication,
+    @PathVariable Long id,
+    @Valid @RequestBody ArticleEdit.TextChangeRequest request
+  ) throws IOException {
+    return ApiResponse.ok(
+      HttpMethod.POST,
+      articleAssemble.editArticle(id, request)
+    );
+  }
+
+  @PatchMapping(path = "/{id}/thumbnail", consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
+  @Operation(summary = "아티클 썸네일 이미지 업데이트")
+  @Tag(name = "[화면]-아티클")
+  public ApiResponse<String> registerImage(
+    @AuthenticationPrincipal JwtAuthentication authentication,
+    @PathVariable Long id,
+    @RequestPart MultipartFile image,
+    @Valid @RequestPart Long seriesId
+  ) throws IOException {
+    return ApiResponse.ok(
+      HttpMethod.PATCH,
+      this.articleAssemble.changeThumbnail(image, seriesId, id, authentication.userId)
+    );
+  }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/article/app/ArticleController.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/app/ArticleController.java
@@ -25,7 +25,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/article")
 @Tag(name = "Article")
 public class ArticleController {
-
   private final ArticleAssemble articleAssemble;
 
   public ArticleController(

--- a/src/main/java/com/prgrms/monthsub/module/series/article/app/ArticleService.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/app/ArticleService.java
@@ -1,61 +1,39 @@
 package com.prgrms.monthsub.module.series.article.app;
 
-import com.prgrms.monthsub.common.utils.S3Uploader;
-import com.prgrms.monthsub.config.S3.Bucket;
-import com.prgrms.monthsub.module.series.article.converter.ArticleConverter;
 import com.prgrms.monthsub.module.series.article.domain.Article;
-import com.prgrms.monthsub.module.series.series.domain.Series;
+import com.prgrms.monthsub.module.series.article.domain.exception.ArticleException.ArticleNotFound;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.UUID;
 
 @Service
 @Transactional(readOnly = true)
 public class ArticleService {
-    private final ArticleRepository articleRepository;
-    private final S3Uploader s3Uploader;
+  private final ArticleRepository articleRepository;
 
-    public ArticleService(
-            ArticleRepository articleRepository,
-            ArticleConverter articleConverter,
-            S3Uploader s3Uploader
-    ) {
-        this.articleRepository = articleRepository;
-        this.s3Uploader = s3Uploader;
-    }
+  public ArticleService(
+    ArticleRepository articleRepository
+  ) {
+    this.articleRepository = articleRepository;
+  }
 
-    public Long save(Article article) {
-        return this.articleRepository.save(article).getId();
-    }
+  @Transactional
+  public Long save(Article article) {
+    return this.articleRepository.save(article)
+      .getId();
+  }
 
-    public List<Article> getArticleListBySeriesId(Long seriesId) {
-        return this.articleRepository.findAllArticleBySeriesId(seriesId);
-    }
+  public Article find(Long id) {
+    return this.articleRepository.findById(id)
+      .orElseThrow(() -> new ArticleNotFound("articleId=" + id));
+  }
 
-    public Long countBySeriesId(Long seriesId) {
-        return this.articleRepository.countBySeriesId(seriesId);
-    }
+  public List<Article> getArticleListBySeriesId(Long seriesId) {
+    return this.articleRepository.findAllArticleBySeriesId(seriesId);
+  }
 
-    protected String uploadThumbnailImage(
-            MultipartFile image,
-            Long seriesId,
-            Long id
-    ) throws IOException {
-        String key = Series.class.getSimpleName()
-                .toLowerCase()
-                + "/" + seriesId.toString()
-                + "/" + Article.class.getSimpleName()
-                .toLowerCase()
-                + "/" + id.toString()
-                + "/thumbnail/"
-                + UUID.randomUUID() +
-                this.s3Uploader.getExtension(image);
-
-        return this.s3Uploader.upload(Bucket.IMAGE, image, key, S3Uploader.imageExtensions);
-    }
+  public Long countBySeriesId(Long seriesId) {
+    return this.articleRepository.countBySeriesId(seriesId);
+  }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/article/converter/ArticleConverter.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/converter/ArticleConverter.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ArticleConverter {
-
   private final S3 s3;
 
   public ArticleConverter(S3 s3) {this.s3 = s3;}
@@ -37,8 +36,8 @@ public class ArticleConverter {
     );
   }
 
-  public String toThumbnailEndpoint(String thumnnailKey) {
-    return this.s3.getDomain() + "/" + thumnnailKey;
+  public String toThumbnailEndpoint(String thumbnailKey) {
+    return this.s3.getDomain() + "/" + thumbnailKey;
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/article/converter/ArticleConverter.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/converter/ArticleConverter.java
@@ -1,5 +1,6 @@
 package com.prgrms.monthsub.module.series.article.converter;
 
+import com.prgrms.monthsub.config.S3;
 import com.prgrms.monthsub.module.series.article.domain.Article;
 import com.prgrms.monthsub.module.series.article.dto.ArticlePost;
 import com.prgrms.monthsub.module.series.series.domain.Series;
@@ -8,6 +9,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ArticleConverter {
+
+  private final S3 s3;
+
+  public ArticleConverter(S3 s3) {this.s3 = s3;}
 
   public Article ArticlePostToEntity(
     Series series,
@@ -30,6 +35,10 @@ public class ArticleConverter {
       article.getCreatedAt()
         .toLocalDate()
     );
+  }
+
+  public String toThumbnailEndpoint(String thumnnailKey) {
+    return this.s3.getDomain() + "/" + thumnnailKey;
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/article/domain/Article.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/domain/Article.java
@@ -50,4 +50,11 @@ public class Article extends BaseEntity {
     this.thumbnailKey = thumbnailKey;
   }
 
+  public void changeWriting(
+    String title,
+    String contents
+  ) {
+    this.title = title;
+    this.contents = contents;
+  }
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/article/domain/exception/ArticleException.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/domain/exception/ArticleException.java
@@ -1,5 +1,19 @@
 package com.prgrms.monthsub.module.series.article.domain.exception;
 
+import com.prgrms.monthsub.common.exception.base.BusinessException;
+import com.prgrms.monthsub.common.exception.model.ErrorCodes;
+import java.util.Arrays;
+
 public class ArticleException {
+
+  public static class ArticleNotFound extends BusinessException {
+
+    public ArticleNotFound(String... message) {
+      super(ErrorCodes.ENTITY_NOT_FOUND(Arrays.stream(message)
+        .toList()
+        .toString()));
+    }
+
+  }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/article/dto/ArticleEdit.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/dto/ArticleEdit.java
@@ -3,12 +3,10 @@ package com.prgrms.monthsub.module.series.article.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
 
-public class ArticlePost {
+public class ArticleEdit {
 
-  @Schema(name = "ArticlePost.Request")
-  public record Request(
-    Long seriesId,
-
+  @Schema(name = "ArticleEdit.TextChangeRequest")
+  public record TextChangeRequest(
     @NotBlank
     String title,
 
@@ -17,8 +15,8 @@ public class ArticlePost {
   ) {
   }
 
-  @Schema(name = "ArticlePost.Response")
-  public record Response(
+  @Schema(name = "ArticleEdit.TextChangeResponse")
+  public record TextChangeResponse(
     Long id
   ) {
   }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/app/SeriesService.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/app/SeriesService.java
@@ -134,17 +134,4 @@ public class SeriesService {
     return this.s3Uploader.upload(Bucket.IMAGE, image, key, S3Uploader.imageExtensions);
   }
 
-  public String updateThumbnailImage(
-    MultipartFile image,
-    Long id
-  ) throws IOException {
-    Series series = this.seriesRepository.getById(id);
-    String thumbnailKey = this.uploadThumbnailImage(image, series.getId());
-    series.changeThumbnailKey(thumbnailKey);
-
-    return this.seriesRepository
-      .save(series)
-      .getThumbnailKey();
-  }
-
 }


### PR DESCRIPTION
## 🦓 지라 link
https://monthsub.atlassian.net/browse/MON-24?atlOrigin=eyJpIjoiYjc4NGUwZjQ5ZmNhNDk1OTlkZjYyYTA0ZWU4NTBiNDkiLCJwIjoiaiJ9

## 👩‍💻 AS-IS

- [x] :  제목, 컨텐츠 수정 api / 아티클 썸네일 수정 api 분리해서 구현했습니다.
- [x] : 썸네일 수정 api 요청시에 이전 이미지는 expulsion 테이블에서 관리할 수 있도록 하였습니다.
