### PR TITLE
[MON-146] feat:  Explusion table 이미지 상태관리하는 Admin API 구현

### DIFF
--- a/src/main/java/com/prgrms/monthsub/common/s3/config/S3.java
+++ b/src/main/java/com/prgrms/monthsub/common/s3/config/S3.java
@@ -24,6 +24,10 @@ public class S3 {
 
   public enum Bucket {
     IMAGE, VIDEO;
+
+    public static Bucket of(String bucket) {
+      return Bucket.valueOf(bucket.toUpperCase());
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/prgrms/monthsub/common/security/config/SecurityConfig.java
@@ -121,6 +121,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
       .authorizeRequests()
       .antMatchers("/users/me")
       .hasAnyRole("USER")
+      .antMatchers("/expulsion")
+      .hasAnyRole("ADMIN")
       .anyRequest()
       .fullyAuthenticated()
       .and()

--- a/src/main/java/com/prgrms/monthsub/module/part/user/app/UserService.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/user/app/UserService.java
@@ -10,7 +10,9 @@ import com.prgrms.monthsub.module.part.user.domain.exception.UserException.NickN
 import com.prgrms.monthsub.module.part.user.domain.exception.UserException.UserNotFound;
 import com.prgrms.monthsub.module.part.user.dto.UserEdit;
 import com.prgrms.monthsub.module.part.user.dto.UserSignUp;
+import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.DomainType;
 import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.FileCategory;
+import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.FileType;
 import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.Status;
 import com.prgrms.monthsub.module.worker.explusion.domain.ExpulsionService;
 import java.util.Optional;
@@ -117,8 +119,7 @@ public class UserService implements UserProvider {
           return this.s3Client.upload(
             Bucket.IMAGE,
             imageFile,
-            key,
-            S3Client.imageExtensions
+            key
           );
         }
       )
@@ -128,8 +129,13 @@ public class UserService implements UserProvider {
 
     if (originalProfileKey != null) {
       expulsionService.save(
-        user.getId(), originalProfileKey, Status.CREATED,
-        FileCategory.USER_PROFILE
+        user.getId(),
+        user.getId(),
+        originalProfileKey,
+        Status.CREATED,
+        DomainType.USER,
+        FileCategory.USER_PROFILE,
+        FileType.IMAGE
       );
     }
 

--- a/src/main/java/com/prgrms/monthsub/module/series/article/app/ArticleAssemble.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/app/ArticleAssemble.java
@@ -11,7 +11,9 @@ import com.prgrms.monthsub.module.series.article.dto.ArticleOne;
 import com.prgrms.monthsub.module.series.article.dto.ArticlePost;
 import com.prgrms.monthsub.module.series.series.app.SeriesService;
 import com.prgrms.monthsub.module.series.series.domain.Series;
+import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.DomainType;
 import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.FileCategory;
+import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.FileType;
 import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.Status;
 import com.prgrms.monthsub.module.worker.explusion.domain.ExpulsionService;
 import java.util.UUID;
@@ -113,8 +115,13 @@ public class ArticleAssemble {
     );
 
     expulsionService.save(
-      userId, originalThumbnailKey, Status.CREATED,
-      FileCategory.ARTICLE_THUMBNAIL
+      articleId,
+      userId,
+      originalThumbnailKey,
+      Status.CREATED,
+      DomainType.ARTICLE,
+      FileCategory.ARTICLE_THUMBNAIL,
+      FileType.IMAGE
     );
 
     article.changeThumbnailKey(thumbnailKey);
@@ -137,7 +144,7 @@ public class ArticleAssemble {
       + UUID.randomUUID() +
       this.s3Client.getExtension(image);
 
-    return this.s3Client.upload(Bucket.IMAGE, image, key, S3Client.imageExtensions);
+    return this.s3Client.upload(Bucket.IMAGE, image, key);
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/app/SeriesAssemble.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/app/SeriesAssemble.java
@@ -17,7 +17,9 @@ import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList;
 import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.Response;
 import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeOne;
 import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribePost;
+import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.DomainType;
 import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.FileCategory;
+import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.FileType;
 import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.Status;
 import com.prgrms.monthsub.module.worker.explusion.domain.ExpulsionService;
 import java.util.Arrays;
@@ -191,8 +193,13 @@ public class SeriesAssemble {
     );
 
     expulsionService.save(
-      userId, originalThumbnailKey, Status.CREATED,
-      FileCategory.SERIES_THUMBNAIL
+      seriesId,
+      userId,
+      originalThumbnailKey,
+      Status.CREATED,
+      DomainType.SERIES,
+      FileCategory.SERIES_THUMBNAIL,
+      FileType.IMAGE
     );
 
     series.changeThumbnailKey(thumbnailKey);
@@ -211,7 +218,7 @@ public class SeriesAssemble {
       + UUID.randomUUID() +
       this.s3Client.getExtension(image);
 
-    return this.s3Client.upload(Bucket.IMAGE, image, key, S3Client.imageExtensions);
+    return this.s3Client.upload(Bucket.IMAGE, image, key);
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/worker/explusion/domain/Expulsion.java
+++ b/src/main/java/com/prgrms/monthsub/module/worker/explusion/domain/Expulsion.java
@@ -10,15 +10,12 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Entity
 @Table(name = "expulsion")
 public class Expulsion {
@@ -58,6 +55,32 @@ public class Expulsion {
 
   @Column(name = "hard_delete_date", columnDefinition = "TIMESTAMP")
   private LocalDateTime hardDeleteDate;
+
+  @Builder
+  private Expulsion(
+    Long domainId,
+    Long userId,
+    String fileKey,
+    Status status,
+    DomainType domainType,
+    FileCategory fileCategory,
+    FileType fileType
+  ) {
+    this.domainId = domainId;
+    this.userId = userId;
+    this.fileKey = fileKey;
+    this.status = status;
+    this.domainType = domainType;
+    this.fileCategory = fileCategory;
+    this.fileType = fileType;
+    this.softDeleteDate = LocalDateTime.now();
+  }
+
+  public Expulsion hardDelete() {
+    this.hardDeleteDate = LocalDateTime.now();
+    this.status = Status.DELETED;
+    return this;
+  }
 
   public enum Status {
     CREATED,

--- a/src/main/java/com/prgrms/monthsub/module/worker/explusion/domain/ExpulsionController.java
+++ b/src/main/java/com/prgrms/monthsub/module/worker/explusion/domain/ExpulsionController.java
@@ -1,0 +1,26 @@
+package com.prgrms.monthsub.module.worker.explusion.domain;
+
+import com.prgrms.monthsub.common.s3.config.S3.Bucket;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/expulsion")
+public class ExpulsionController {
+
+  private final ExpulsionService expulsionService;
+
+  public ExpulsionController(ExpulsionService expulsionService) {
+    this.expulsionService = expulsionService;
+  }
+
+  @DeleteMapping
+  @Operation(hidden = true)
+  public void deleteBulk(@RequestParam(value = "bucket", required = true) String bucket) {
+    this.expulsionService.deleteBulk(Bucket.of(bucket));
+  }
+
+}

--- a/src/main/java/com/prgrms/monthsub/module/worker/explusion/domain/ExpulsionController.java
+++ b/src/main/java/com/prgrms/monthsub/module/worker/explusion/domain/ExpulsionController.java
@@ -1,7 +1,10 @@
 package com.prgrms.monthsub.module.worker.explusion.domain;
 
 import com.prgrms.monthsub.common.s3.config.S3.Bucket;
+import com.prgrms.monthsub.common.security.jwt.JwtAuthentication;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,8 +21,12 @@ public class ExpulsionController {
   }
 
   @DeleteMapping
-  @Operation(hidden = true)
-  public void deleteBulk(@RequestParam(value = "bucket", required = true) String bucket) {
+  @Operation(summary = "어드민 API")
+  @Tag(name = "[화면]-없음")
+  public void deleteBulk(
+    @AuthenticationPrincipal JwtAuthentication authentication,
+    @RequestParam(value = "bucket", required = true) String bucket
+  ) {
     this.expulsionService.deleteBulk(Bucket.of(bucket));
   }
 

--- a/src/main/java/com/prgrms/monthsub/module/worker/explusion/domain/ExpulsionRepository.java
+++ b/src/main/java/com/prgrms/monthsub/module/worker/explusion/domain/ExpulsionRepository.java
@@ -1,6 +1,17 @@
 package com.prgrms.monthsub.module.worker.explusion.domain;
 
+import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.Status;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ExpulsionRepository extends JpaRepository<Expulsion, Long> {
+
+  List<Expulsion> findAllByStatus(
+    Status status,
+    Pageable pageable
+  );
+
+  long countByStatus(Status status);
+
 }

--- a/src/main/java/com/prgrms/monthsub/module/worker/explusion/domain/ExpulsionService.java
+++ b/src/main/java/com/prgrms/monthsub/module/worker/explusion/domain/ExpulsionService.java
@@ -1,31 +1,82 @@
 package com.prgrms.monthsub.module.worker.explusion.domain;
 
+import com.prgrms.monthsub.common.s3.S3Client;
+import com.prgrms.monthsub.common.s3.config.S3.Bucket;
+import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.DomainType;
 import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.FileCategory;
+import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.FileType;
 import com.prgrms.monthsub.module.worker.explusion.domain.Expulsion.Status;
+import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ExpulsionService {
+
+  private final int CHUNK_SIZE = 100;
   private final ExpulsionRepository expulsionRepository;
+  private final S3Client s3Client;
 
   public ExpulsionService(
-    ExpulsionRepository expulsionRepository
-  ) {this.expulsionRepository = expulsionRepository;}
+
+    ExpulsionRepository expulsionRepository,
+    S3Client s3Client
+  ) {
+    this.expulsionRepository = expulsionRepository;
+    this.s3Client = s3Client;
+  }
 
   public void save(
+    Long domainId,
     Long userId,
     String originalKey,
     Status status,
-    FileCategory fileCategory
+    DomainType domainType,
+    FileCategory fileCategory,
+    FileType fileType
   ) {
-//    Expulsion expulsion = Expulsion.builder()
-//      .userId(userId)
-//      .fileKey(originalKey)
-//      .status(status)
-//      .fileCategory(fileCategory)
-//      .hardDeleteDate(LocalDateTime.now())
-//      .build();
-//    this.expulsionRepository.save(expulsion);
+    Expulsion expulsion = Expulsion.builder()
+      .domainId(domainId)
+      .userId(userId)
+      .fileKey(originalKey)
+      .status(status)
+      .domainType(domainType)
+      .fileCategory(fileCategory)
+      .fileType(fileType)
+      .build();
+
+    this.expulsionRepository.save(expulsion);
+  }
+
+  @Transactional
+  public void deleteBulk(Bucket bucket) {
+    long totalCount = this.expulsionRepository.countByStatus(Status.CREATED);
+    long loopCount = (long) Math.ceil(totalCount / (double) CHUNK_SIZE);
+
+    for (int i = 0; i < loopCount; i++) {
+      List<Expulsion> expulsions = this.expulsionRepository
+        .findAllByStatus(
+          Status.CREATED,
+          PageRequest.of(
+            0,
+            CHUNK_SIZE,
+            Sort.by(Direction.ASC, "softDeleteDate", "id")
+          )
+        );
+
+      this.s3Client.deleteKeys(
+        bucket,
+        expulsions
+          .stream()
+          .map(Expulsion::getFileKey)
+          .toList()
+      );
+
+      expulsions.forEach(Expulsion::hardDelete);
+    }
   }
 
 }


### PR DESCRIPTION
## 🦓 지라 link
https://monthsub.atlassian.net/browse/MON-146?atlOrigin=eyJpIjoiNDFkZjQ1MWUwOTI2NDEzN2JmYzQyYTg1Zjc0NTE0Y2QiLCJwIjoiaiJ9

## 👩‍💻 AS-IS

- [x] :  Explusion table 이미지 상태관리하는 Admin API 구현했습니다. 청크사이즈를 100으로 지정했습니다.