### PR TITLE
[MON-135] feat:  작가의 시리즈 발행 리스트 조회 API

### DIFF
--- a/src/main/java/com/prgrms/monthsub/module/part/writer/app/WriterService.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/writer/app/WriterService.java
@@ -41,6 +41,7 @@ public class WriterService implements WriterProvider {
       .orElseGet(() -> this.getWriterAndChangeUserPart(userId));
   }
 
+  @Override
   public Writer findWriterByUserId(Long userId) {
     return this.writerRepository
       .findByUserId(userId)

--- a/src/main/java/com/prgrms/monthsub/module/part/writer/app/provider/WriterProvider.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/writer/app/provider/WriterProvider.java
@@ -6,4 +6,6 @@ public interface WriterProvider {
 
   Writer findByUserId(Long userId);
 
+  Writer findWriterByUserId(Long userId);
+
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/app/SeriesAssemble.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/app/SeriesAssemble.java
@@ -177,6 +177,16 @@ public class SeriesAssemble {
       .collect(Collectors.toList()));
   }
 
+  public SeriesSubscribeList.Response getSeriesPostList(Long userId) {
+    return new SeriesSubscribeList.Response(
+      this.seriesService.findAllByWriterId(this.writerProvider.findWriterByUserId(userId)
+          .getId())
+        .stream()
+        .map(seriesConverter::seriesListToResponse)
+        .collect(Collectors.toList())
+    );
+  }
+
   @Transactional
   public String changeThumbnail(
     MultipartFile thumbnail,

--- a/src/main/java/com/prgrms/monthsub/module/series/series/app/SeriesController.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/app/SeriesController.java
@@ -114,6 +114,15 @@ public class SeriesController {
     return this.seriesAssemble.changeThumbnail(file, id, authentication.userId);
   }
 
+  @GetMapping("/writer/posts")
+  @Operation(summary = "작가가 발행한 시리즈 리스트")
+  @Tag(name = "[화면]-시리즈")
+  public SeriesSubscribeList.Response getSeriesPostList(
+    @AuthenticationPrincipal JwtAuthentication authentication
+  ) {
+    return this.seriesAssemble.getSeriesPostList(authentication.userId);
+  }
+
   @GetMapping("/search/title")
   @Operation(summary = "시리즈 제목으로 리스트 조회(검색)")
   @Tag(name = "[화면]-시리즈")


### PR DESCRIPTION
## 🦓 지라 link
https://monthsub.atlassian.net/browse/MON-135?atlOrigin=eyJpIjoiN2JjZDJkZDNjNTYzNDJjMzhjZjdjNzcwNDRhMWMxYjQiLCJwIjoiaiJ9

## 👩‍💻 AS-IS

- [x] :  작가가 발행한 시리즈 리스트 조회
	* 토큰을 통해 `userId`를 가져오고 이 값으로 `writerId`를 찾아 Series에서 조건을 걸고 가져오도록 하였습니다.
	
## ✅ 궁금한 점
 `end_point` 가 `/series/posts` 일때는 500 에러가 발생한다. 
 그래서 `/series/writer/posts` 로 변경하였더니 잘 돌아갑니다.  원인이 무엇인지 궁금합니다. 
  
