### PR TITLE
chore: 작가 시리즈 발행 리스트 조회 API 버그 수정

### DIFF
--- a/src/main/java/com/prgrms/monthsub/module/part/writer/app/provider/WriterProvider.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/writer/app/provider/WriterProvider.java
@@ -6,6 +6,6 @@ public interface WriterProvider {
 
   Writer findByUserId(Long userId);
 
-  Writer findById(Long userId);
+  Writer findById(Long id);
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/app/SeriesAssemble.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/app/SeriesAssemble.java
@@ -254,8 +254,7 @@ public class SeriesAssemble {
   public SeriesSubscribeList.Response getSeriesPostList(Long userId) {
     return new SeriesSubscribeList.Response(
       this.seriesService
-        .findAllByWriterId(this.writerProvider.findById(userId)
-          .getId())
+        .findAllByWriterId(this.writerProvider.findByUserId(userId).getId())
         .stream()
         .map(seriesConverter::toResponse)
         .collect(Collectors.toList())


### PR DESCRIPTION
## 🦓 지라 link
https://monthsub.atlassian.net/browse/MON-199?atlOrigin=eyJpIjoiN2U4YjljMjc2M2UzNDRkMjkyMGY2ODIxYzQxMGQwNGYiLCJwIjoiaiJ9

## 👩‍💻 AS-IS
- [x] :  작가 시리 발행 리스트 조회할때 작가 아이디를 찾아오는 부분에서 작가 id로 찾고 있어서 발행한 버그입니다. userId로 찾아올 수 있게 변경하였습니다.