### PR TITLE
[MON-218] fix: DTO class를 sealed와 record로 변경 작업 

### DIFF
--- a/src/main/java/com/prgrms/monthsub/module/part/user/converter/UserConverter.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/user/converter/UserConverter.java
@@ -4,13 +4,12 @@ import static com.prgrms.monthsub.module.part.user.domain.User.POINT;
 
 import com.prgrms.monthsub.common.s3.config.S3;
 import com.prgrms.monthsub.module.part.user.app.PartService;
-import com.prgrms.monthsub.module.part.user.domain.Part;
 import com.prgrms.monthsub.module.part.user.domain.Part.Name;
 import com.prgrms.monthsub.module.part.user.domain.User;
 import com.prgrms.monthsub.module.part.user.dto.UserMe;
 import com.prgrms.monthsub.module.part.user.dto.UserMe.Response;
 import com.prgrms.monthsub.module.part.user.dto.UserSignUp;
-import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SeriesOneWithUserResponse;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SeriesUserResponse;
 import java.util.Optional;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -32,11 +31,14 @@ public class UserConverter {
     this.bCryptEncoder = bCryptEncoder;
   }
 
-  public SeriesOneWithUserResponse toSeriesOneWithUser(User user, Optional<Long> writerId) {
+  public SeriesUserResponse toSeriesOneWithUser(
+    User user,
+    Optional<Long> writerId
+  ) {
     String profileImage =
       user.getProfileKey() == null ? null : this.s3.getDomain() + "/" + user.getProfileKey();
 
-    return new SeriesOneWithUserResponse(
+    return new SeriesUserResponse(
       user.getId(),
       writerId.orElse(null),
       user.getEmail(),

--- a/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserEdit.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserEdit.java
@@ -1,24 +1,35 @@
 package com.prgrms.monthsub.module.part.user.dto;
 
+import com.prgrms.monthsub.module.part.user.dto.UserEdit.Request;
+import com.prgrms.monthsub.module.part.user.dto.UserEdit.Response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
+import lombok.Builder;
 
-public class UserEdit {
+public sealed interface UserEdit permits Request, Response {
 
   @Schema(name = "UserEdit.Request")
-  public record Request(
+  record Request(
     @NotBlank(message = "닉네임이 비어있습니다.")
     String nickName,
 
     @NotBlank(message = "소개글이 비어있습니다.")
     String profileIntroduce
-  ) {
+  ) implements UserEdit {
+
+    @Builder
+    public Request {
+    }
   }
 
   @Schema(name = "UserEdit.Response")
-  public record Response(
+  record Response(
     Long userId
-  ) {
+  ) implements UserEdit {
+
+    @Builder
+    public Response {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserEdit.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserEdit.java
@@ -16,7 +16,6 @@ public sealed interface UserEdit permits Request, Response {
     @NotBlank(message = "소개글이 비어있습니다.")
     String profileIntroduce
   ) implements UserEdit {
-
     @Builder
     public Request {
     }
@@ -26,7 +25,6 @@ public sealed interface UserEdit permits Request, Response {
   record Response(
     Long userId
   ) implements UserEdit {
-
     @Builder
     public Response {
     }

--- a/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserLogin.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserLogin.java
@@ -1,27 +1,38 @@
 package com.prgrms.monthsub.module.part.user.dto;
 
+import com.prgrms.monthsub.module.part.user.dto.UserLogin.Request;
+import com.prgrms.monthsub.module.part.user.dto.UserLogin.Response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
+import lombok.Builder;
 
-public class UserLogin {
+public sealed interface UserLogin permits Request, Response {
 
   @Schema(name = "Login.Request")
-  public record Request(
+  record Request(
     @NotBlank(message = "이메일이 비어있습니다.")
     String email,
 
     @NotBlank(message = "비밀번호가 비어있습니다.")
     String password
-  ) {
+  ) implements UserLogin {
+
+    @Builder
+    public Request {
+    }
   }
 
   @Schema(name = "Login.Response")
-  public record Response(
+  record Response(
     Long userId,
     String token,
     String email,
     String group
-  ) {
+  ) implements UserLogin {
+
+    @Builder
+    public Response {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserLogin.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserLogin.java
@@ -16,7 +16,6 @@ public sealed interface UserLogin permits Request, Response {
     @NotBlank(message = "비밀번호가 비어있습니다.")
     String password
   ) implements UserLogin {
-
     @Builder
     public Request {
     }
@@ -29,7 +28,6 @@ public sealed interface UserLogin permits Request, Response {
     String email,
     String group
   ) implements UserLogin {
-
     @Builder
     public Response {
     }

--- a/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserMe.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserMe.java
@@ -16,7 +16,6 @@ public sealed interface UserMe permits Response {
     String profileIntroduce,
     String group
   ) implements UserMe {
-
     @Builder
     public Response {
     }

--- a/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserMe.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserMe.java
@@ -1,11 +1,13 @@
 package com.prgrms.monthsub.module.part.user.dto;
 
+import com.prgrms.monthsub.module.part.user.dto.UserMe.Response;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
-public class UserMe {
+public sealed interface UserMe permits Response {
 
   @Schema(name = "UserMe.Response")
-  public record Response(
+  record Response(
     Long userId,
     String email,
     String userName,
@@ -13,7 +15,11 @@ public class UserMe {
     String profileKey,
     String profileIntroduce,
     String group
-  ) {
+  ) implements UserMe {
+
+    @Builder
+    public Response {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserSignUp.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserSignUp.java
@@ -22,7 +22,6 @@ public sealed interface UserSignUp permits Request, Response {
     @NotBlank(message = "닉네임이 비어있습니다.")
     String nickName
   ) implements UserSignUp {
-
     @Builder
     public Request {
     }
@@ -32,7 +31,6 @@ public sealed interface UserSignUp permits Request, Response {
   record Response(
     Long userId
   ) implements UserSignUp {
-
     @Builder
     public Response {
     }

--- a/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserSignUp.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/user/dto/UserSignUp.java
@@ -1,12 +1,15 @@
 package com.prgrms.monthsub.module.part.user.dto;
 
+import com.prgrms.monthsub.module.part.user.dto.UserSignUp.Request;
+import com.prgrms.monthsub.module.part.user.dto.UserSignUp.Response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
+import lombok.Builder;
 
-public class UserSignUp {
+public sealed interface UserSignUp permits Request, Response {
 
   @Schema(name = "SignUp.Request")
-  public record Request(
+  record Request(
     @NotBlank(message = "이메일이 비어있습니다.")
     String email,
 
@@ -18,12 +21,21 @@ public class UserSignUp {
 
     @NotBlank(message = "닉네임이 비어있습니다.")
     String nickName
-  ) {}
+  ) implements UserSignUp {
+
+    @Builder
+    public Request {
+    }
+  }
 
   @Schema(name = "SignUp.Response")
-  public record Response(
+  record Response(
     Long userId
-  ) {
+  ) implements UserSignUp {
+
+    @Builder
+    public Response {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/part/writer/converter/WriterConverter.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/writer/converter/WriterConverter.java
@@ -4,10 +4,10 @@ import com.prgrms.monthsub.common.s3.config.S3;
 import com.prgrms.monthsub.module.part.user.converter.UserConverter;
 import com.prgrms.monthsub.module.part.user.domain.User;
 import com.prgrms.monthsub.module.part.writer.domain.Writer;
-import com.prgrms.monthsub.module.part.writer.dto.WriterLikesList.LikesObject;
+import com.prgrms.monthsub.module.part.writer.dto.WriterLikesList.LikesResponse;
 import com.prgrms.monthsub.module.part.writer.dto.WriterList.WriterResponse;
 import com.prgrms.monthsub.module.series.series.dto.MyChannel;
-import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SeriesOneWithWriterResponse;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SeriesWriterResponse;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
 
@@ -25,8 +25,8 @@ public class WriterConverter {
     this.s3 = s3;
   }
 
-  public SeriesOneWithWriterResponse toSeriesOneWithWriter(Writer writer) {
-    return new SeriesOneWithWriterResponse(
+  public SeriesWriterResponse toSeriesOneWithWriter(Writer writer) {
+    return new SeriesWriterResponse(
       writer.getId(),
       writer.getFollowCount(),
       this.userConverter.toSeriesOneWithUser(writer.getUser(), Optional.of(writer.getId()))
@@ -50,20 +50,20 @@ public class WriterConverter {
   }
 
   public WriterResponse writerToWriterRes(Writer writer) {
-    return new WriterResponse(
-      writer.getUser().getId(),
-      writer.getId(),
-      writer.getUser().getNickname(),
-      writer.getUser().getProfileKey() == null ? null
-        : this.s3.getDomain() + "/" + writer.getUser().getProfileKey(),
-      String.valueOf(writer.getSubScribeStatus())
-    );
+    return WriterResponse.builder()
+      .userId(writer.getUser().getId())
+      .writerId(writer.getId())
+      .nickname(writer.getUser().getNickname())
+      .profileImage(writer.getUser().getProfileKey() == null ? null
+        : this.s3.getDomain() + "/" + writer.getUser().getProfileKey())
+      .subscribeStatus(String.valueOf(writer.getSubScribeStatus()))
+      .build();
   }
 
-  public LikesObject toWriterLikesList(Writer writer) {
+  public LikesResponse toWriterLikesList(Writer writer) {
     User user = writer.getUser();
 
-    return LikesObject.builder()
+    return LikesResponse.builder()
       .writerId(writer.getId())
       .nickname(user.getNickname())
       .profileIntroduce(user.getProfileIntroduce())

--- a/src/main/java/com/prgrms/monthsub/module/part/writer/converter/WriterConverter.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/writer/converter/WriterConverter.java
@@ -67,7 +67,7 @@ public class WriterConverter {
       .writerId(writer.getId())
       .nickname(user.getNickname())
       .profileIntroduce(user.getProfileIntroduce())
-      .profileKey(
+      .profileImage(
         user.getProfileKey() == null
           ? null
           : this.s3.getDomain() + "/" + user.getProfileKey())

--- a/src/main/java/com/prgrms/monthsub/module/part/writer/dto/WriterFollowEvent.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/writer/dto/WriterFollowEvent.java
@@ -1,14 +1,20 @@
 package com.prgrms.monthsub.module.part.writer.dto;
 
+import com.prgrms.monthsub.module.part.writer.dto.WriterFollowEvent.Response;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
-public class WriterFollowEvent {
+public sealed interface WriterFollowEvent permits Response {
 
   @Schema(name = "WriterFollowEvent.Response")
-  public record Response(
+  record Response(
     Long userId,
     String followStatus
-  ) {
+  ) implements WriterFollowEvent {
+
+    @Builder
+    public Response {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/part/writer/dto/WriterFollowEvent.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/writer/dto/WriterFollowEvent.java
@@ -11,7 +11,6 @@ public sealed interface WriterFollowEvent permits Response {
     Long userId,
     String followStatus
   ) implements WriterFollowEvent {
-
     @Builder
     public Response {
     }

--- a/src/main/java/com/prgrms/monthsub/module/part/writer/dto/WriterLikesList.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/writer/dto/WriterLikesList.java
@@ -23,7 +23,7 @@ public sealed interface WriterLikesList permits Response, LikesResponse {
     Long writerId,
     int followCount,
     String nickname,
-    String profileKey,
+    String profileImage,
     String profileIntroduce
   ) implements WriterLikesList {
 

--- a/src/main/java/com/prgrms/monthsub/module/part/writer/dto/WriterLikesList.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/writer/dto/WriterLikesList.java
@@ -12,7 +12,6 @@ public sealed interface WriterLikesList permits Response, LikesResponse {
   record Response(
     List<LikesResponse> writerLikesList
   ) implements WriterLikesList {
-
     @Builder
     public Response {
     }
@@ -26,7 +25,6 @@ public sealed interface WriterLikesList permits Response, LikesResponse {
     String profileImage,
     String profileIntroduce
   ) implements WriterLikesList {
-
     @Builder
     public LikesResponse {
     }

--- a/src/main/java/com/prgrms/monthsub/module/part/writer/dto/WriterLikesList.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/writer/dto/WriterLikesList.java
@@ -1,26 +1,35 @@
 package com.prgrms.monthsub.module.part.writer.dto;
 
+import com.prgrms.monthsub.module.part.writer.dto.WriterLikesList.LikesResponse;
+import com.prgrms.monthsub.module.part.writer.dto.WriterLikesList.Response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
-import lombok.Getter;
 
-public class WriterLikesList {
+public sealed interface WriterLikesList permits Response, LikesResponse {
 
   @Schema(name = "WriterLikes.Response")
-  public record Response(
-    List<LikesObject> writerLikesList
-  ) {
+  record Response(
+    List<LikesResponse> writerLikesList
+  ) implements WriterLikesList {
+
+    @Builder
+    public Response {
+    }
   }
 
-  @Getter
-  @Builder
-  public static class LikesObject {
-    public Long writerId;
-    public int followCount;
-    public String nickname;
-    public String profileKey;
-    public String profileIntroduce;
+  @Schema(name = "WriterLikesList.LikesResponse")
+  record LikesResponse(
+    Long writerId,
+    int followCount,
+    String nickname,
+    String profileKey,
+    String profileIntroduce
+  ) implements WriterLikesList {
+
+    @Builder
+    public LikesResponse {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/part/writer/dto/WriterList.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/writer/dto/WriterList.java
@@ -1,24 +1,35 @@
 package com.prgrms.monthsub.module.part.writer.dto;
 
+import com.prgrms.monthsub.module.part.writer.dto.WriterList.Response;
+import com.prgrms.monthsub.module.part.writer.dto.WriterList.WriterResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import lombok.Builder;
 
-public class WriterList {
+public sealed interface WriterList permits Response, WriterResponse {
 
   @Schema(name = "WriterList.Response")
-  public record Response(
+  record Response(
     List<WriterResponse> popularWriterList
-  ) {
+  ) implements WriterList {
+
+    @Builder
+    public Response {
+    }
   }
 
   @Schema(name = "WriterList.WriterRes")
-  public record WriterResponse(
+  record WriterResponse(
     Long userId,
     Long writerId,
     String nickname,
     String profileImage,
     String subscribeStatus
-  ) {
+  ) implements WriterList {
+
+    @Builder
+    public WriterResponse {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/part/writer/dto/WriterList.java
+++ b/src/main/java/com/prgrms/monthsub/module/part/writer/dto/WriterList.java
@@ -12,7 +12,6 @@ public sealed interface WriterList permits Response, WriterResponse {
   record Response(
     List<WriterResponse> popularWriterList
   ) implements WriterList {
-
     @Builder
     public Response {
     }
@@ -26,7 +25,6 @@ public sealed interface WriterList permits Response, WriterResponse {
     String profileImage,
     String subscribeStatus
   ) implements WriterList {
-
     @Builder
     public WriterResponse {
     }

--- a/src/main/java/com/prgrms/monthsub/module/payment/dto/PaymentPost.java
+++ b/src/main/java/com/prgrms/monthsub/module/payment/dto/PaymentPost.java
@@ -1,17 +1,20 @@
 package com.prgrms.monthsub.module.payment.dto;
 
+import com.prgrms.monthsub.module.payment.dto.PaymentPost.PaymentSeries;
+import com.prgrms.monthsub.module.payment.dto.PaymentPost.Response;
+import com.prgrms.monthsub.module.payment.dto.PaymentPost.UserPoint;
 import com.prgrms.monthsub.module.series.series.domain.Series.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import lombok.Builder;
 
-public class PaymentPost {
+public sealed interface PaymentPost permits PaymentSeries, Response, UserPoint {
   @Schema(name = "PaymentPost.Response")
-  public record Response(
+  record Response(
     PaymentSeries series,
     UserPoint user
-  ) {
+  ) implements PaymentPost {
   }
 
   @Schema(name = "PaymentPost.PaymentSeries")
@@ -27,9 +30,8 @@ public class PaymentPost {
     LocalDate endDate,
     String[] date,
     LocalTime time
-  ) {
-
-    @Builder()
+  ) implements PaymentPost {
+    @Builder
     public PaymentSeries {
     }
   }
@@ -37,8 +39,7 @@ public class PaymentPost {
   @Schema(name = "PaymentPost.UserPoint")
   record UserPoint(
     int point
-  ) {
-
+  ) implements PaymentPost {
     @Builder
     public UserPoint {
     }

--- a/src/main/java/com/prgrms/monthsub/module/payment/dto/PaymentPost.java
+++ b/src/main/java/com/prgrms/monthsub/module/payment/dto/PaymentPost.java
@@ -14,24 +14,34 @@ public class PaymentPost {
   ) {
   }
 
-  @Builder
-  public static class PaymentSeries {
-    public String email;
-    public String nickname;
-    public String title;
-    public String thumbnail;
-    public Category category;
-    public int price;
-    public int articleCount;
-    public LocalDate startDate;
-    public LocalDate endDate;
-    public String[] date;
-    public LocalTime time;
+  @Schema(name = "PaymentPost.PaymentSeries")
+  record PaymentSeries(
+    String email,
+    String nickname,
+    String title,
+    String thumbnail,
+    Category category,
+    int price,
+    int articleCount,
+    LocalDate startDate,
+    LocalDate endDate,
+    String[] date,
+    LocalTime time
+  ) {
+
+    @Builder()
+    public PaymentSeries {
+    }
   }
 
-  @Builder
-  public static class UserPoint {
-    public int point;
+  @Schema(name = "PaymentPost.UserPoint")
+  record UserPoint(
+    int point
+  ) {
+
+    @Builder
+    public UserPoint {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/payment/dto/PaymentSeries.java
+++ b/src/main/java/com/prgrms/monthsub/module/payment/dto/PaymentSeries.java
@@ -22,7 +22,6 @@ public sealed interface PaymentSeries permits Response {
     String[] date,
     String time
   ) implements PaymentSeries {
-
     @Builder
     public Response {
     }

--- a/src/main/java/com/prgrms/monthsub/module/payment/dto/PaymentSeries.java
+++ b/src/main/java/com/prgrms/monthsub/module/payment/dto/PaymentSeries.java
@@ -1,13 +1,15 @@
 package com.prgrms.monthsub.module.payment.dto;
 
+import com.prgrms.monthsub.module.payment.dto.PaymentSeries.Response;
 import com.prgrms.monthsub.module.series.series.domain.Series.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
+import lombok.Builder;
 
-public class PaymentSeries {
+public sealed interface PaymentSeries permits Response {
 
   @Schema(name = "PaymentSeries.Response")
-  public record Response(
+  record Response(
     String email,
     String nickname,
     String title,
@@ -19,6 +21,11 @@ public class PaymentSeries {
     LocalDate endDate,
     String[] date,
     String time
-  ) {}
+  ) implements PaymentSeries {
+
+    @Builder
+    public Response {
+    }
+  }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/article/converter/ArticleConverter.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/converter/ArticleConverter.java
@@ -46,20 +46,19 @@ public class ArticleConverter {
     Long articleCount,
     User user
   ) {
-    return new ArticleOne.Response(
-      isMine,
-      article.getTitle(),
-      article.getContents(),
-      this.toThumbnailEndpoint(article.getThumbnailKey()),
-      articleCount.intValue(),
-      user.getNickname(),
-      (user.getProfileKey() == null
-        ? null
-        : this.s3.getDomain() + "/" + user.getProfileKey()),
-      user.getProfileIntroduce(),
-      article.getCreatedAt().toLocalDate(),
-      article.getUpdateAt().toLocalDate()
-    );
+    return ArticleOne.Response.builder()
+      .isMine(isMine)
+      .title(article.getTitle())
+      .contents(article.getContents())
+      .thumbnailKey(this.toThumbnailEndpoint(article.getThumbnailKey()))
+      .round(articleCount.intValue())
+      .nickname(user.getNickname())
+      .profileKey(
+        user.getProfileKey() == null ? null : this.s3.getDomain() + "/" + user.getProfileKey())
+      .profileIntroduce(user.getProfileIntroduce())
+      .createdDate(article.getCreatedAt().toLocalDate())
+      .updatedDate(article.getUpdateAt().toLocalDate())
+      .build();
   }
 
   public String toThumbnailEndpoint(String thumbnailKey) {

--- a/src/main/java/com/prgrms/monthsub/module/series/article/dto/ArticleEdit.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/dto/ArticleEdit.java
@@ -1,12 +1,15 @@
 package com.prgrms.monthsub.module.series.article.dto;
 
+import com.prgrms.monthsub.module.series.article.dto.ArticleEdit.ChangeRequest;
+import com.prgrms.monthsub.module.series.article.dto.ArticleEdit.ChangeResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
+import lombok.Builder;
 
-public class ArticleEdit {
+public sealed interface ArticleEdit permits ChangeRequest, ChangeResponse {
 
   @Schema(name = "ArticleEdit.ChangeRequest")
-  public record ChangeRequest(
+  record ChangeRequest(
     @NotBlank
     String title,
 
@@ -14,14 +17,22 @@ public class ArticleEdit {
     String contents,
 
     Long seriesId
-  ) {
+  ) implements ArticleEdit {
+
+    @Builder
+    public ChangeRequest {
+    }
   }
 
   @Schema(name = "ArticleEdit.ChangeResponse")
-  public record ChangeResponse(
+  record ChangeResponse(
     Long id,
     Boolean isMine
-  ) {
+  ) implements ArticleEdit {
+
+    @Builder
+    public ChangeResponse {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/article/dto/ArticleEdit.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/dto/ArticleEdit.java
@@ -18,7 +18,6 @@ public sealed interface ArticleEdit permits ChangeRequest, ChangeResponse {
 
     Long seriesId
   ) implements ArticleEdit {
-
     @Builder
     public ChangeRequest {
     }
@@ -29,7 +28,6 @@ public sealed interface ArticleEdit permits ChangeRequest, ChangeResponse {
     Long id,
     Boolean isMine
   ) implements ArticleEdit {
-
     @Builder
     public ChangeResponse {
     }

--- a/src/main/java/com/prgrms/monthsub/module/series/article/dto/ArticleOne.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/dto/ArticleOne.java
@@ -1,12 +1,14 @@
 package com.prgrms.monthsub.module.series.article.dto;
 
+import com.prgrms.monthsub.module.series.article.dto.ArticleOne.Response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
+import lombok.Builder;
 
-public class ArticleOne {
+public sealed interface ArticleOne permits Response {
 
   @Schema(name = "ArticleOne.Response")
-  public record Response(
+  record Response(
     Boolean isMine,
     String title,
     String contents,
@@ -17,7 +19,11 @@ public class ArticleOne {
     String profileIntroduce,
     LocalDate createdDate,
     LocalDate updatedDate
-  ) {
+  ) implements ArticleOne {
+
+    @Builder
+    public Response {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/article/dto/ArticleOne.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/dto/ArticleOne.java
@@ -20,7 +20,6 @@ public sealed interface ArticleOne permits Response {
     LocalDate createdDate,
     LocalDate updatedDate
   ) implements ArticleOne {
-
     @Builder
     public Response {
     }

--- a/src/main/java/com/prgrms/monthsub/module/series/article/dto/ArticlePost.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/dto/ArticlePost.java
@@ -1,12 +1,15 @@
 package com.prgrms.monthsub.module.series.article.dto;
 
+import com.prgrms.monthsub.module.series.article.dto.ArticlePost.Request;
+import com.prgrms.monthsub.module.series.article.dto.ArticlePost.Response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
+import lombok.Builder;
 
-public class ArticlePost {
+public sealed interface ArticlePost permits Request, Response {
 
   @Schema(name = "ArticlePost.Request")
-  public record Request(
+  record Request(
     Long seriesId,
 
     @NotBlank
@@ -14,14 +17,22 @@ public class ArticlePost {
 
     @NotBlank
     String contents
-  ) {
+  ) implements ArticlePost {
+
+    @Builder
+    public Request {
+    }
   }
 
   @Schema(name = "ArticlePost.Response")
-  public record Response(
+  record Response(
     Long id,
     Boolean isMine
-  ) {
+  ) implements ArticlePost {
+
+    @Builder
+    public Response {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/article/dto/ArticlePost.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/article/dto/ArticlePost.java
@@ -18,7 +18,6 @@ public sealed interface ArticlePost permits Request, Response {
     @NotBlank
     String contents
   ) implements ArticlePost {
-
     @Builder
     public Request {
     }
@@ -29,7 +28,6 @@ public sealed interface ArticlePost permits Request, Response {
     Long id,
     Boolean isMine
   ) implements ArticlePost {
-
     @Builder
     public Response {
     }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/converter/SeriesConverter.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/converter/SeriesConverter.java
@@ -11,7 +11,7 @@ import com.prgrms.monthsub.module.series.series.domain.Series.Category;
 import com.prgrms.monthsub.module.series.series.domain.Series.SeriesStatus;
 import com.prgrms.monthsub.module.series.series.dto.MyChannel;
 import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList;
-import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SeriesOneWithWriterResponse;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SeriesWriterResponse;
 import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SubscribeObject;
 import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.UploadObject;
 import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.WriterObject;
@@ -72,7 +72,7 @@ public class SeriesConverter {
     List<ArticleUploadDate> uploadDateList,
     Boolean isMine
   ) {
-    SeriesOneWithWriterResponse writerResponse = writerConverter.toSeriesOneWithWriter(
+    SeriesWriterResponse writerResponse = writerConverter.toSeriesOneWithWriter(
       series.getWriter());
     return new Response(
       series.isLikedStatus(),
@@ -122,7 +122,7 @@ public class SeriesConverter {
 
   public SeriesSubscribeList.SeriesListObject toResponse(Series series) {
     return SeriesSubscribeList.SeriesListObject.builder()
-      .liked(series.isLikedStatus())
+      .isLiked(series.isLikedStatus())
       .userId(series.getWriter().getUser().getId())
       .writerId(series.getWriter().getId())
       .nickname(series.getWriter().getUser().getNickname())
@@ -171,7 +171,7 @@ public class SeriesConverter {
 
   public MyChannel.SubscribeObject toMyChannelSubscribeObject(Series series) {
     return MyChannel.SubscribeObject.builder()
-      .liked(series.isLikedStatus())
+      .isLiked(series.isLikedStatus())
       .userId(series.getWriter().getUser().getId())
       .writerId(series.getWriter().getId())
       .nickname(series.getWriter().getUser().getNickname())
@@ -191,7 +191,7 @@ public class SeriesConverter {
 
   public MyChannel.SeriesObject toMyChannelSeriesObject(Series series) {
     return MyChannel.SeriesObject.builder()
-      .liked(series.isLikedStatus())
+      .isLiked(series.isLikedStatus())
       .userId(series.getWriter().getUser().getId())
       .writerId(series.getWriter().getId())
       .nickname(series.getWriter().getUser().getNickname())

--- a/src/main/java/com/prgrms/monthsub/module/series/series/dto/MyChannel.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/dto/MyChannel.java
@@ -1,91 +1,113 @@
 package com.prgrms.monthsub.module.series.series.dto;
 
 import com.prgrms.monthsub.module.series.series.domain.Series;
-import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SeriesOneWithUserResponse;
+import com.prgrms.monthsub.module.series.series.dto.MyChannel.FollowWriterObject;
+import com.prgrms.monthsub.module.series.series.dto.MyChannel.OtherResponse;
+import com.prgrms.monthsub.module.series.series.dto.MyChannel.Response;
+import com.prgrms.monthsub.module.series.series.dto.MyChannel.SeriesObject;
+import com.prgrms.monthsub.module.series.series.dto.MyChannel.SubscribeObject;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SeriesUserResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 
-public class MyChannel {
+public sealed interface MyChannel permits Response, OtherResponse, FollowWriterObject,
+  SubscribeObject, SeriesObject {
 
   @Schema(name = "MyChannel.Response")
-  public record Response(
+  record Response(
     Boolean isFollowed,
     Boolean isMine,
-    SeriesOneWithUserResponse user,
+    SeriesUserResponse user,
     int followIngCount,
     List<MyChannel.FollowWriterObject> followWriterList,
     List<MyChannel.SubscribeObject> subscribeList,
     int followCount,
     List<MyChannel.SeriesObject> seriesPostList
-  ) {
+  ) implements MyChannel {
+
+    @Builder
+    public Response {
+    }
   }
 
   @Schema(name = "MyChannel.OtherResponse")
-  public record OtherResponse(
+  record OtherResponse(
     Boolean isFollowed,
     Boolean isMine,
-    SeriesOneWithUserResponse user,
+    SeriesUserResponse user,
     int followIngCount,
     List<MyChannel.FollowWriterObject> followWriterList,
     int followCount,
     List<MyChannel.SeriesObject> seriesPostList
-  ) {
+  ) implements MyChannel {
+
+    @Builder
+    public OtherResponse {
+    }
   }
 
-  @Builder
-  @Getter
-  public static class FollowWriterObject {
-    Long userId;
-    Long writerId;
-    String nickname;
-    String profileImage;
-    String subscribeStatus;
+  @Schema(name = "MyChannel.FollowWriterObject")
+  record FollowWriterObject(
+    Long userId,
+    Long writerId,
+    String nickname,
+    String profileImage,
+    String subscribeStatus
+  ) implements MyChannel {
+
+    @Builder
+    public FollowWriterObject {
+    }
   }
 
-  @Builder
-  @Getter
-  @Accessors(fluent = true, prefix = "is")
-  public static class SubscribeObject {
-    public Boolean isLiked;
-    public Long userId;
-    public Long writerId;
-    public Long seriesId;
-    public String nickname;
-    public String thumbnail;
-    public String title;
-    public String introduceSentence;
-    public LocalDate seriesStartDate;
-    public LocalDate seriesEndDate;
-    public String subscribeStatus;
-    public LocalDate subscribeStartDate;
-    public LocalDate subscribeEndDate;
-    public int likes;
-    public Series.Category category;
+  @Schema(name = "MyChannel.SubscribeObject")
+  record SubscribeObject(
+    Boolean isLiked,
+    Long userId,
+    Long writerId,
+    Long seriesId,
+    String nickname,
+    String thumbnail,
+    String title,
+    String introduceSentence,
+    LocalDate seriesStartDate,
+    LocalDate seriesEndDate,
+    String subscribeStatus,
+    LocalDate subscribeStartDate,
+    LocalDate subscribeEndDate,
+    int likes,
+    Series.Category category
+  ) implements MyChannel {
+
+    @Builder
+    public SubscribeObject {
+    }
   }
 
-  @Builder
-  @Getter
-  @Accessors(fluent = true, prefix = "is")
-  public static class SeriesObject {
-    public Boolean isLiked;
-    public Long userId;
-    public Long writerId;
-    public Long seriesId;
-    public String nickname;
-    public String thumbnail;
-    public String title;
-    public String introduceSentence;
-    public LocalDate seriesStartDate;
-    public LocalDate seriesEndDate;
-    public String subscribeStatus;
-    public LocalDate subscribeStartDate;
-    public LocalDate subscribeEndDate;
-    public int likes;
-    public Series.Category category;
+  @Schema(name = "MyChannel.SeriesObject")
+  record SeriesObject(
+    Boolean isLiked,
+    Long userId,
+    Long writerId,
+    Long seriesId,
+    String nickname,
+    String thumbnail,
+    String title,
+    String introduceSentence,
+    LocalDate seriesStartDate,
+    LocalDate seriesEndDate,
+    String subscribeStatus,
+    LocalDate subscribeStartDate,
+    LocalDate subscribeEndDate,
+    int likes,
+    Series.Category category
+  ) implements MyChannel {
+
+    @Builder
+    public SeriesObject {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/dto/MyChannel.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/dto/MyChannel.java
@@ -26,7 +26,6 @@ public sealed interface MyChannel permits Response, OtherResponse, FollowWriterO
     int followCount,
     List<MyChannel.SeriesObject> seriesPostList
   ) implements MyChannel {
-
     @Builder
     public Response {
     }
@@ -42,7 +41,6 @@ public sealed interface MyChannel permits Response, OtherResponse, FollowWriterO
     int followCount,
     List<MyChannel.SeriesObject> seriesPostList
   ) implements MyChannel {
-
     @Builder
     public OtherResponse {
     }
@@ -56,7 +54,6 @@ public sealed interface MyChannel permits Response, OtherResponse, FollowWriterO
     String profileImage,
     String subscribeStatus
   ) implements MyChannel {
-
     @Builder
     public FollowWriterObject {
     }
@@ -80,7 +77,6 @@ public sealed interface MyChannel permits Response, OtherResponse, FollowWriterO
     int likes,
     Series.Category category
   ) implements MyChannel {
-
     @Builder
     public SubscribeObject {
     }
@@ -104,7 +100,6 @@ public sealed interface MyChannel permits Response, OtherResponse, FollowWriterO
     int likes,
     Series.Category category
   ) implements MyChannel {
-
     @Builder
     public SeriesObject {
     }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesLikesEvent.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesLikesEvent.java
@@ -11,10 +11,8 @@ public sealed interface SeriesLikesEvent permits Response {
     Long id,
     String likeStatus
   ) implements SeriesLikesEvent {
-
     @Builder
     public Response {
-
     }
   }
 

--- a/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesLikesEvent.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesLikesEvent.java
@@ -1,14 +1,21 @@
 package com.prgrms.monthsub.module.series.series.dto;
 
+import com.prgrms.monthsub.module.series.series.dto.SeriesLikesEvent.Response;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
-public class SeriesLikesEvent {
+public sealed interface SeriesLikesEvent permits Response {
 
   @Schema(name = "SeriesLike.Response")
-  public record Response(
+  record Response(
     Long id,
     String likeStatus
-  ) {
+  ) implements SeriesLikesEvent {
+
+    @Builder
+    public Response {
+
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesLikesList.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesLikesList.java
@@ -12,7 +12,6 @@ public sealed interface SeriesLikesList permits Response {
   record Response(
     List<SeriesListObject> seriesList
   ) implements SeriesLikesList {
-
     @Builder
     public Response {
     }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesLikesList.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesLikesList.java
@@ -1,15 +1,21 @@
 package com.prgrms.monthsub.module.series.series.dto;
 
+import com.prgrms.monthsub.module.series.series.dto.SeriesLikesList.Response;
 import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SeriesListObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import lombok.Builder;
 
-public class SeriesLikesList {
+public sealed interface SeriesLikesList permits Response {
 
   @Schema(name = "SeriesLikesList.Response")
-  public record Response(
+  record Response(
     List<SeriesListObject> seriesList
-  ) {
+  ) implements SeriesLikesList {
+
+    @Builder
+    public Response {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribeEdit.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribeEdit.java
@@ -1,12 +1,15 @@
 package com.prgrms.monthsub.module.series.series.dto;
 
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeEdit.Request;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeEdit.Response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
+import lombok.Builder;
 
-public class SeriesSubscribeEdit {
+public sealed interface SeriesSubscribeEdit permits Request, Response {
 
   @Schema(name = "SeriesSubscribeEdit.Request")
-  public record Request(
+  record Request(
     Long writerId,
 
     @NotBlank(message = "제목이 비어있습니다.")
@@ -22,14 +25,22 @@ public class SeriesSubscribeEdit {
 
     @NotBlank(message = "업로드 시간이 비어있습니다.")
     String uploadTime
-  ) {
+  ) implements SeriesSubscribeEdit {
+
+    @Builder
+    public Request {
+    }
   }
 
   @Schema(name = "SeriesSubscribeEdit.Response")
-  public record Response(
+  record Response(
     Long seriesId,
     Boolean isMine
-  ) {
+  ) implements SeriesSubscribeEdit {
+
+    @Builder
+    public Response {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribeEdit.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribeEdit.java
@@ -26,7 +26,6 @@ public sealed interface SeriesSubscribeEdit permits Request, Response {
     @NotBlank(message = "업로드 시간이 비어있습니다.")
     String uploadTime
   ) implements SeriesSubscribeEdit {
-
     @Builder
     public Request {
     }
@@ -37,7 +36,6 @@ public sealed interface SeriesSubscribeEdit permits Request, Response {
     Long seriesId,
     Boolean isMine
   ) implements SeriesSubscribeEdit {
-
     @Builder
     public Response {
     }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribeList.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribeList.java
@@ -23,7 +23,6 @@ public sealed interface SeriesSubscribeList permits Response, SeriesUserResponse
   record Response(
     List<SeriesListObject> seriesList
   ) implements SeriesSubscribeList {
-
     @Builder
     public Response {
     }
@@ -38,7 +37,6 @@ public sealed interface SeriesSubscribeList permits Response, SeriesUserResponse
     String profileIntroduce,
     String nickname
   ) implements SeriesSubscribeList {
-
     @Builder
     public SeriesUserResponse {
     }
@@ -50,7 +48,6 @@ public sealed interface SeriesSubscribeList permits Response, SeriesUserResponse
     int followCount,
     SeriesUserResponse user
   ) implements SeriesSubscribeList {
-
     @Builder
     public SeriesWriterResponse {
     }
@@ -63,7 +60,6 @@ public sealed interface SeriesSubscribeList permits Response, SeriesUserResponse
     Integer round,
     LocalDate date
   ) implements SeriesSubscribeList {
-
     @Builder
     public BriefArticleResponse {
     }
@@ -87,7 +83,6 @@ public sealed interface SeriesSubscribeList permits Response, SeriesUserResponse
     int likes,
     Series.Category category
   ) implements SeriesSubscribeList {
-
     @Builder
     public SeriesListObject {
     }
@@ -108,7 +103,6 @@ public sealed interface SeriesSubscribeList permits Response, SeriesUserResponse
     LocalDate createdDate,
     LocalDate updatedDate
   ) implements SeriesSubscribeList {
-
     @Builder
     public SeriesObject {
     }
@@ -119,7 +113,6 @@ public sealed interface SeriesSubscribeList permits Response, SeriesUserResponse
     String[] date,
     String time
   ) implements SeriesSubscribeList {
-
     @Builder
     public UploadObject {
     }
@@ -131,7 +124,6 @@ public sealed interface SeriesSubscribeList permits Response, SeriesUserResponse
     LocalDate endDate,
     String status
   ) implements SeriesSubscribeList {
-
     @Builder
     public SubscribeObject {
     }
@@ -147,7 +139,6 @@ public sealed interface SeriesSubscribeList permits Response, SeriesUserResponse
     String profileIntroduce,
     String nickname
   ) implements SeriesSubscribeList {
-
     @Builder
     public WriterObject {
     }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribeList.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribeList.java
@@ -1,108 +1,156 @@
 package com.prgrms.monthsub.module.series.series.dto;
 
 import com.prgrms.monthsub.module.series.series.domain.Series;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.BriefArticleResponse;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.Response;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SeriesListObject;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SeriesObject;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SeriesUserResponse;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SeriesWriterResponse;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SubscribeObject;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.UploadObject;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.WriterObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 
-public class SeriesSubscribeList {
+public sealed interface SeriesSubscribeList permits Response, SeriesUserResponse,
+  SeriesWriterResponse, BriefArticleResponse, SeriesListObject, SeriesObject,
+  UploadObject, SubscribeObject, WriterObject {
 
   @Schema(name = "SeriesSubscribeList.Response")
-  public record Response(
+  record Response(
     List<SeriesListObject> seriesList
-  ) {
+  ) implements SeriesSubscribeList {
+
+    @Builder
+    public Response {
+    }
   }
 
-  @Schema(name = "SeriesSubscribeList.SeriesOneWithUserResponse")
-  public record SeriesOneWithUserResponse(
+  @Schema(name = "SeriesSubscribeList.SeriesUserResponse")
+  record SeriesUserResponse(
     Long userId,
     Long writerId,
     String email,
     String profileImage,
     String profileIntroduce,
     String nickname
-  ) {
+  ) implements SeriesSubscribeList {
+
+    @Builder
+    public SeriesUserResponse {
+    }
   }
 
-  @Schema(name = "SeriesSubScribeList.SeriesOneWithWriterResponse")
-  public record SeriesOneWithWriterResponse(
+  @Schema(name = "SeriesSubScribeList.SeriesWriterResponse")
+  record SeriesWriterResponse(
     Long writerId,
     int followCount,
-    SeriesOneWithUserResponse user
-  ) {
+    SeriesUserResponse user
+  ) implements SeriesSubscribeList {
+
+    @Builder
+    public SeriesWriterResponse {
+    }
   }
 
-  @Schema(name = "SeriesSubScribeList.BriefArticleBySeriesIdResponse")
-  public record BriefArticleResponse(
+  @Schema(name = "SeriesSubScribeList.BriefArticleResponse")
+  record BriefArticleResponse(
     Long articleId,
     String title,
     Integer round,
     LocalDate date
-  ) {
+  ) implements SeriesSubscribeList {
+
+    @Builder
+    public BriefArticleResponse {
+    }
   }
 
-  @Getter
-  @Builder
-  @Accessors(fluent = true, prefix = "is")
-  public static class SeriesListObject {
-    public Boolean isLiked;
-    public Long userId;
-    public Long writerId;
-    public Long seriesId;
-    public String nickname;
-    public String thumbnail;
-    public String title;
-    public String introduceSentence;
-    public LocalDate seriesStartDate;
-    public LocalDate seriesEndDate;
-    public String subscribeStatus;
-    public LocalDate subscribeStartDate;
-    public LocalDate subscribeEndDate;
-    public int likes;
-    public Series.Category category;
+  @Schema(name = "SeriesSubScribeList.SeriesListObject")
+  record SeriesListObject(
+    Boolean isLiked,
+    Long userId,
+    Long writerId,
+    Long seriesId,
+    String nickname,
+    String thumbnail,
+    String title,
+    String introduceSentence,
+    LocalDate seriesStartDate,
+    LocalDate seriesEndDate,
+    String subscribeStatus,
+    LocalDate subscribeStartDate,
+    LocalDate subscribeEndDate,
+    int likes,
+    Series.Category category
+  ) implements SeriesSubscribeList {
+
+    @Builder
+    public SeriesListObject {
+    }
   }
 
-  @Builder
-  public static class SeriesObject {
-    public Long id;
-    public String thumbnail;
-    public String title;
-    public String introduceText;
-    public String introduceSentence;
-    public int price;
-    public LocalDate startDate;
-    public LocalDate endDate;
-    public int articleCount;
-    public int likes;
-    public LocalDate createdDate;
-    public LocalDate updatedDate;
+  @Schema(name = "SeriesSubScribeList.SeriesObject")
+  record SeriesObject(
+    Long id,
+    String thumbnail,
+    String title,
+    String introduceText,
+    String introduceSentence,
+    int price,
+    LocalDate startDate,
+    LocalDate endDate,
+    int articleCount,
+    int likes,
+    LocalDate createdDate,
+    LocalDate updatedDate
+  ) implements SeriesSubscribeList {
+
+    @Builder
+    public SeriesObject {
+    }
   }
 
-  @Builder
-  public static class UploadObject {
-    public String[] date;
-    public String time;
+  @Schema(name = "SeriesSubScribeList.UploadObject")
+  record UploadObject(
+    String[] date,
+    String time
+  ) implements SeriesSubscribeList {
+
+    @Builder
+    public UploadObject {
+    }
   }
 
-  @Builder
-  public static class SubscribeObject {
-    public LocalDate startDate;
-    public LocalDate endDate;
-    public String status;
+  @Schema(name = "SeriesSubScribeList.SubscribeObject")
+  record SubscribeObject(
+    LocalDate startDate,
+    LocalDate endDate,
+    String status
+  ) implements SeriesSubscribeList {
+
+    @Builder
+    public SubscribeObject {
+    }
   }
 
-  @Builder
-  public static class WriterObject {
-    public Long id;
-    public Long userId;
-    public int followCount;
-    public String email;
-    public String profileImage;
-    public String profileIntroduce;
-    public String nickname;
+  @Schema(name = "SeriesSubScribeList.WriterObject")
+  record WriterObject(
+    Long id,
+    Long userId,
+    int followCount,
+    String email,
+    String profileImage,
+    String profileIntroduce,
+    String nickname
+  ) implements SeriesSubscribeList {
+
+    @Builder
+    public WriterObject {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribeOne.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribeOne.java
@@ -24,7 +24,6 @@ public sealed interface SeriesSubscribeOne permits Response, UsageEditResponse {
     WriterObject writer,
     List<BriefArticleResponse> articleList
   ) implements SeriesSubscribeOne {
-
     @Builder
     public Response {
     }
@@ -37,7 +36,6 @@ public sealed interface SeriesSubscribeOne permits Response, UsageEditResponse {
     UploadObject upload,
     SubscribeObject subscribe
   ) implements SeriesSubscribeOne {
-
     @Builder
     public UsageEditResponse {
     }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribeOne.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribeOne.java
@@ -2,17 +2,19 @@ package com.prgrms.monthsub.module.series.series.dto;
 
 import com.prgrms.monthsub.module.series.series.domain.Series.Category;
 import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.BriefArticleResponse;
-import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SeriesObject;
 import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.SubscribeObject;
 import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.UploadObject;
 import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeList.WriterObject;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeOne.Response;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribeOne.UsageEditResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import lombok.Builder;
 
-public class SeriesSubscribeOne {
+public sealed interface SeriesSubscribeOne permits Response, UsageEditResponse {
 
   @Schema(name = "SeriesSubscribeOne.Response")
-  public record Response(
+  record Response(
     Boolean isLiked,
     Boolean isMine,
     SeriesSubscribeList.SeriesObject series,
@@ -21,16 +23,24 @@ public class SeriesSubscribeOne {
     Category category,
     WriterObject writer,
     List<BriefArticleResponse> articleList
-  ) {
+  ) implements SeriesSubscribeOne {
+
+    @Builder
+    public Response {
+    }
   }
 
   @Schema(name = "SeriesSubscribeOne.ResponseUsageEdit")
-  public record UsageEditResponse(
+  record UsageEditResponse(
     SeriesSubscribeList.SeriesObject series,
     Category category,
     UploadObject upload,
     SubscribeObject subscribe
-  ) {
+  ) implements SeriesSubscribeOne {
+
+    @Builder
+    public UsageEditResponse {
+    }
   }
 
 }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribePost.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribePost.java
@@ -47,7 +47,6 @@ public sealed interface SeriesSubscribePost permits Request, Response {
     @PositiveOrZero
     int price
   ) implements SeriesSubscribePost {
-
     @Builder
     public Request {
     }
@@ -57,7 +56,6 @@ public sealed interface SeriesSubscribePost permits Request, Response {
   record Response(
     Long seriesId
   ) implements SeriesSubscribePost {
-
     @Builder
     public Response {
     }

--- a/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribePost.java
+++ b/src/main/java/com/prgrms/monthsub/module/series/series/dto/SeriesSubscribePost.java
@@ -1,14 +1,17 @@
 package com.prgrms.monthsub.module.series.series.dto;
 
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribePost.Request;
+import com.prgrms.monthsub.module.series.series.dto.SeriesSubscribePost.Response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
+import lombok.Builder;
 
-public class SeriesSubscribePost {
+public sealed interface SeriesSubscribePost permits Request, Response {
 
   @Schema(name = "SeriesSubscribePost.Request")
-  public record Request(
+  record Request(
     @NotBlank(message = "제목이 비어있습니다.")
     String title,
 
@@ -43,13 +46,21 @@ public class SeriesSubscribePost {
 
     @PositiveOrZero
     int price
-  ) {
+  ) implements SeriesSubscribePost {
+
+    @Builder
+    public Request {
+    }
   }
 
   @Schema(name = "SeriesSubscribePost.Response")
-  public record Response(
+  record Response(
     Long seriesId
-  ) {
+  ) implements SeriesSubscribePost {
+
+    @Builder
+    public Response {
+    }
   }
 
 }


### PR DESCRIPTION
## 🦓 지라 link
https://monthsub.atlassian.net/browse/MON-218?atlOrigin=eyJpIjoiMGExOTg2NjkzYzYzNDIzMWJkMTA4ODY1ZjczYzRhMmMiLCJwIjoiaiJ9

## 👩‍💻 AS-IS

- [x] :  기존 DTO를 `class`로 관리하던 형태를 JDK17의 `sealed` 와 `record`를 이용하여 변경해주었다.